### PR TITLE
Fix Alias Source Code

### DIFF
--- a/Sources/DesignTokensCore/DesignTokenTree.swift
+++ b/Sources/DesignTokensCore/DesignTokenTree.swift
@@ -25,7 +25,7 @@ package struct DesignTokenTree {
         tokens.append(token)
 
       case let .alias(path):
-        let alias = AliasToken(name: node.name, description: node.description, path: path)
+        let alias = AliasToken(name: node.name, description: node.description, path: node.path, reference: path)
         aliases.append(alias)
 
       default:
@@ -35,10 +35,6 @@ package struct DesignTokenTree {
 
     tokens.sort()
     aliases.sort()
-
-    aliases.removeAll { alias in
-      !tokens.contains { $0.path == alias.path }
-    }
 
     return (tokens, aliases)
   }
@@ -56,7 +52,7 @@ package struct DesignTokenTree {
         tokens.append(token)
 
       case let .alias(path):
-        let alias = AliasToken(name: node.name, description: node.description, path: path)
+        let alias = AliasToken(name: node.name, description: node.description, path: node.path, reference: path)
         aliases.append(alias)
 
       default:
@@ -66,10 +62,6 @@ package struct DesignTokenTree {
 
     tokens.sort()
     aliases.sort()
-
-    aliases.removeAll { alias in
-      !tokens.contains { $0.path == alias.path }
-    }
 
     return (tokens, aliases)
   }

--- a/Sources/DesignTokensCore/Token/AliasToken.swift
+++ b/Sources/DesignTokensCore/Token/AliasToken.swift
@@ -8,12 +8,16 @@ package struct AliasToken: Token {
   /// The optional description of the token.
   let description: String?
 
-  /// The path to the referenced token.
+  /// The path to the token.
   let path: Path
 
-  init(name: String, description: String? = nil, path: Path) {
+  /// The path to the referenced token.
+  let reference: Path
+  
+  init(name: String, description: String? = nil, path: Path, reference: Path) {
     self.name = name
     self.description = description
     self.path = path
+    self.reference = reference
   }
 }

--- a/Sources/DesignTokensGenerator/Resources/common.stencil
+++ b/Sources/DesignTokensGenerator/Resources/common.stencil
@@ -1,7 +1,7 @@
 {% macro aliasesBlock aliases aliasType %}
   {% for alias in aliases %}
-  {% set aliasName %}{{alias.name|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set referenceName %}{{alias.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
+  {% set aliasName %}{{alias.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
+  {% set referenceName %}{{alias.reference|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
   static var {{aliasName}}: {{aliasType}} { {{referenceName}} }
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
Fixed the generation of source code for aliases.

### Changelog
- Fixed an issue where some aliases would be ignored if the referenced token was not contained in the same file of the alias.
- Fixed an issue where the name of the aliases would not preserve the path of the alias.