### PR TITLE
Improve Init and Generate Commands Options

### DIFF
--- a/Sources/DesignTokensGenerator/Configuration/Configuration.swift
+++ b/Sources/DesignTokensGenerator/Configuration/Configuration.swift
@@ -143,10 +143,10 @@ extension Configuration {
 
 extension Configuration {
   /// Creates a default instance for the `Configuration`.
-  static func scaffold() -> Configuration {
+  static func scaffold(inputPaths: [String], outputPath: String) -> Configuration {
     Configuration()
-      .input("design-tokens.json")
-      .output("Output/")
+      .inputs(inputPaths)
+      .output(outputPath)
       .color(
         formats: .swiftUI, .uiKit
       )

--- a/Sources/DesignTokensGenerator/Constants.swift
+++ b/Sources/DesignTokensGenerator/Constants.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-package let defaultConfigurationFileName = "design-tokens-configuration"
+package let defaultConfigurationFileName = "design-tokens-configuration.json"

--- a/Sources/DesignTokensGenerator/Generators/ConfigurationGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/ConfigurationGenerator.swift
@@ -9,20 +9,27 @@ package struct ConfigurationGenerator {
   private let configurationLocator: ConfigurationLocator
 
   /// The path to the input design tokens file.
-  private let inputPath: String
+  private let inputPaths: [String]
+
+  /// The path to the directory where the output will be generated.
+  private let outputPath: String
 
   // MARK: - Init
   
-  package init(fileName: String?, configurationURL: URL, inputPath: String) {
+  package init(fileName: String?, configurationURL: URL, inputPaths: [String], outputPath: String) {
     self.configurationLocator = ConfigurationLocator(fileName: fileName, configurationURL: configurationURL)
-    self.inputPath = inputPath
+    self.inputPaths = inputPaths
+    self.outputPath = outputPath
   }
 
   // MARK: - Functions
   
   /// Generates the configuration manifest.
   package func generate() throws {
-    let configuration = Configuration.scaffold()
+    let configuration = Configuration.scaffold(
+      inputPaths: inputPaths,
+      outputPath: outputPath
+    )
 
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]

--- a/Sources/DesignTokensTool/Generate.swift
+++ b/Sources/DesignTokensTool/Generate.swift
@@ -7,8 +7,8 @@ struct Generate: ParsableCommand {
 
   @Option(
     name: [
-      .customShort("p"),
-      .customLong("path")
+      .customShort("c"),
+      .customLong("configuration")
     ],
     help: """
       The path to the tool configuration file.

--- a/Sources/DesignTokensTool/Init.swift
+++ b/Sources/DesignTokensTool/Init.swift
@@ -7,9 +7,9 @@ struct Init: ParsableCommand {
 
   @Option(
     name: .shortAndLong,
-    help: "The name of the configuration file. (default: \(defaultConfigurationFileName)"
+    help: "The name of the configuration file."
   )
-  var name: String?
+  var name: String = defaultConfigurationFileName
 
   @Option(
     name: [
@@ -30,13 +30,23 @@ struct Init: ParsableCommand {
     ],
     help: "The path to the design tokens JSON file."
   )
-  var inputPath: String
+  var inputPaths: [String] = ["design-tokens.json"]
+
+  @Option(
+    name: [
+      .customShort("o"),
+      .customLong("output")
+    ],
+    help: "The path to the directory where the output will be generated."
+  )
+  var outputPath: String = "Output/"
 
   func run() throws {
     let configurationGenerator = ConfigurationGenerator(
       fileName: name,
       configurationURL: configurationURL,
-      inputPath: inputPath
+      inputPaths: inputPaths,
+      outputPath: outputPath
     )
     try configurationGenerator.generate()
   }

--- a/Tests/GeneratorTests/ConfigurationGeneratorTests.swift
+++ b/Tests/GeneratorTests/ConfigurationGeneratorTests.swift
@@ -8,7 +8,12 @@ struct ConfigurationGeneratorTests {
   func configurationManifestGeneration() throws {
     let directoryURL = FileManager.default.temporaryDirectory
     
-    let configurationGenerator = ConfigurationGenerator(fileName: "configuration", configurationURL: directoryURL, inputPath: "design-tokens.json")
+    let configurationGenerator = ConfigurationGenerator(
+      fileName: "configuration",
+      configurationURL: directoryURL,
+      inputPaths: ["design-tokens.json"],
+      outputPath: "Output/"
+    )
     try configurationGenerator.generate()
     
     let outputURL = directoryURL

--- a/Tests/GeneratorTests/ConfigurationValidatorTests.swift
+++ b/Tests/GeneratorTests/ConfigurationValidatorTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct ConfigurationValidatorTests {
   @Test(
     arguments: [
-      Configuration.scaffold(),
+      Configuration.scaffold(inputPaths: ["design-tokens.json"], outputPath: "Output/"),
       Configuration().input("design-tokens.json").output("Output/"),
       Configuration().color(inputPath: "design-tokens.json", outputPath: "Output", formats: .swiftUI),
       Configuration().dimension(inputPath: "design-tokens.json", outputPath: "Output"),


### PR DESCRIPTION
Improved the options for the `init`, and `generate` commands.

### Changelog
- The `input` option in the `init` command now supports an array of input paths.
- The `init` command now supports specifying a global output path via the `output` option.
- The path to the configuration file in the `generate` command is now specified via the `configuration` option. – #15 