### PR TITLE
Fix Stencil Color Initializer

### DIFF
--- a/Sources/DesignTokensGenerator/Resources/color+swiftui.stencil
+++ b/Sources/DesignTokensGenerator/Resources/color+swiftui.stencil
@@ -5,7 +5,7 @@ import SwiftUI
 
 {% import "common.stencil" %}
 {% set tokenType %}Color{% endset %}
-{% macro colorValue color %}{{tokenType}}(red: {{ color.red }}, blue: {{ color.blue }}, green: {{ color.green }}, opacity: {{ color.alpha }}){% endmacro %}
+{% macro colorValue color %}{{tokenType}}(red: {{ color.red }}, green: {{ color.green }}, blue: {{ color.blue }}, opacity: {{ color.alpha }}){% endmacro %}
 {% macro tokensBlock tokens %}
   {% for token in tokens %}
   {% if token.description %}

--- a/Sources/DesignTokensGenerator/Resources/color+uikit.stencil
+++ b/Sources/DesignTokensGenerator/Resources/color+uikit.stencil
@@ -5,7 +5,7 @@ import UIKit
 
 {% import "common.stencil" %}
 {% set tokenType %}UIColor{% endset %}
-{% macro colorValue color %}{{tokenType}}(red: {{ color.red }}, blue: {{ color.blue }}, green: {{ color.green }}, alpha: {{ color.alpha }}){% endmacro %}
+{% macro colorValue color %}{{tokenType}}(red: {{ color.red }}, green: {{ color.green }}, blue: {{ color.blue }}, alpha: {{ color.alpha }}){% endmacro %}
 {% macro tokensBlock tokens %}
   {% for token in tokens %}
   {% if token.description %}


### PR DESCRIPTION
Fixed an issue where the `Color`, and `UIColor` initializers were not correct in the Stencil templates.