### PR TITLE
Add Gradient and Number Token Types

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -11,6 +11,12 @@ The command line tool requires a configuration manifest file to generate source 
 - `dimensions`: The tool will generate outputs for any dimension tokens in the design tokens JSON.
   - `input`: The path to the input design token files. (default: global `input`)
   - `output`: The path of the directory where the output should be generated. (default: global `output`)
+- `numbers`: The tool will generate outputs for any number tokens in the design tokens JSON.
+  - `input`: The path to the input design token files. (default: global `input`)
+  - `output`: The path of the directory where the output should be generated. (default: global `output`)
+- `gradients`: The tool will generate outputs for any gradient tokens in the design tokens JSON. Requires `numbers` to be set.
+  - `input`: The path to the input design token files. (default: global `input`)
+  - `output`: The path of the directory where the output should be generated. (default: global `output`)
 
 ## Examples
 

--- a/Documentation/Output.md
+++ b/Documentation/Output.md
@@ -69,6 +69,16 @@ extension CGFloat {
 }
 ```
 
+### Number
+
+Number tokens are generated as an extension on Foundation's `CGFloat` type.
+
+```swift
+extension CGFloat {
+  static let gradientStart: CGFloat = 0.0
+}
+```
+
 ### Gradient
 
 Gradient tokens do not currently support format customization, and will default to SwiftUI source code generation, by extending the `Gradient` type.
@@ -79,10 +89,10 @@ extension Gradient {
     stops: [
       Gradient.Stop(
         color: Color(red: 0.0, green: 0.0, blue: 1.0, opacity: 1.0),
-        location: 0.0
+        location: gradientStart
       ),
       Gradient.Stop(
-        color: Color(red: 1.0, green: 0.0, blue: 0.0, opacity: 1.0),
+        color: red,
         location: 1.0
       ),
     ]

--- a/Documentation/Output.md
+++ b/Documentation/Output.md
@@ -63,19 +63,29 @@ Similarly to the SwiftUI format, the UIKit format extends the `UIColor` type.
 
 Dimension tokens do not support format customization, as the generated source code is always an extension on Foundation's `CGFloat` type.
 
-```json
-{
-  "small": {
-    "$type": "dimension",
-    "$value": "16 px"
-  }
-}
-```
-
-The resulting source code output is as follows:
-
 ```swift
 extension CGFloat {
   static let small: CGFloat = 16
+}
+```
+
+### Gradient
+
+Gradient tokens do not currently support format customization, and will default to SwiftUI source code generation, by extending the `Gradient` type.
+
+```swift
+extension Gradient {
+  static let blueToRed = Gradient(
+    stops: [
+      Gradient.Stop(
+        color: Color(red: 0.0, green: 0.0, blue: 1.0, opacity: 1.0),
+        location: 0.0
+      ),
+      Gradient.Stop(
+        color: Color(red: 1.0, green: 0.0, blue: 0.0, opacity: 1.0),
+        location: 1.0
+      ),
+    ]
+  )
 }
 ```

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
         .copy("Resources/color+uikit.stencil"),
         .copy("Resources/dimension+foundation.stencil"),
         .copy("Resources/gradient+swiftui.stencil"),
+        .copy("Resources/number+foundation.stencil"),
       ]
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
         .copy("Resources/color+swiftui.stencil"),
         .copy("Resources/color+uikit.stencil"),
         .copy("Resources/dimension+foundation.stencil"),
+        .copy("Resources/gradient+swiftui.stencil"),
       ]
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,7 @@ let package = Package(
       resources: [
         .copy("Resources/alias.json"),
         .copy("Resources/color.json"),
+        .copy("Resources/gradient.json"),
         .copy("Resources/groups.json"),
         .copy("Resources/missingTypeFailure.json"),
         .copy("Resources/missingTypeWithAlias.json"),

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## What's `design-tokens`?
 
 `design-tokens` is a command line tool to translate design tokens into Swift source code.
-This package follows the [W3C Design Token standard](https://tr.designtokens.org/format/#:~:text=The%20names%20of%20the%20groups,which%20is%20a%20computed%20property) for the translation.
+This package follows the [W3C Design Token standard](https://tr.designtokens.org/format/) for the translation.
 
 ## Install
 

--- a/Sources/DesignTokensCore/Decoding/TokenValueDecodingConfiguration.swift
+++ b/Sources/DesignTokensCore/Decoding/TokenValueDecodingConfiguration.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// The configuration for the decoding of a `TokenValue`.
+package struct TokenValueDecodingConfiguration {
+
+  // MARK: - Stored properties
+
+  /// The name of the token.
+  let name: String
+
+  /// The path to the token in the tree.
+  let path: Path
+
+  /// The type of the token.
+  ///
+  /// This value is passed down the decoding process from parent groups.
+  /// This is needed, since the `$type` property is not required.
+  /// If a token has no type, [it should be determined from a parent group](https://tr.designtokens.org/format/#type-0).
+  let type: TokenType?
+
+  // MARK: - Init
+
+  init(name: String, path: Path, type: TokenType? = nil) {
+    self.name = name
+    self.path = path
+    self.type = type
+  }
+}

--- a/Sources/DesignTokensCore/DesignTokenTree.swift
+++ b/Sources/DesignTokensCore/DesignTokenTree.swift
@@ -13,25 +13,6 @@ package struct DesignTokenTree {
   init() {
     self.root = Node(name: "Design Tokens")
   }
-
-  package func gradientTokens() -> [GradientToken] {
-    var tokens: [GradientToken] = []
-
-    root.depthFirstTraversal { node in
-      switch node.value {
-      case let .gradient(gradient):
-        let token = GradientToken(name: node.name, description: node.description, gradient: gradient, path: node.path)
-        tokens.append(token)
-
-      default:
-        break
-      }
-    }
-
-    tokens.sort()
-
-    return tokens
-  }
 }
 
 extension DesignTokenTree: Decodable {

--- a/Sources/DesignTokensCore/DesignTokenTree.swift
+++ b/Sources/DesignTokensCore/DesignTokenTree.swift
@@ -65,6 +65,25 @@ package struct DesignTokenTree {
 
     return (tokens, aliases)
   }
+
+  package func gradientTokens() -> [GradientToken] {
+    var tokens: [GradientToken] = []
+
+    root.depthFirstTraversal { node in
+      switch node.value {
+      case let .gradient(gradient):
+        let token = GradientToken(name: node.name, description: node.description, gradient: gradient, path: node.path)
+        tokens.append(token)
+
+      default:
+        break
+      }
+    }
+
+    tokens.sort()
+
+    return tokens
+  }
 }
 
 extension DesignTokenTree: Decodable {

--- a/Sources/DesignTokensCore/Errors/DecodingFailure.swift
+++ b/Sources/DesignTokensCore/Errors/DecodingFailure.swift
@@ -16,6 +16,9 @@ enum DecodingFailure: Error {
   
   /// The decoded alias value is invalid.
   case invalidAliasValue(tokenName: String, tokenPath: [String], valueFailure: AliasValueFailure)
+  
+  /// The decoded gradient value is invalid.
+  case invalidGradientValue(tokenName: String, tokenPath: [String])
 }
 
 extension DecodingFailure: Equatable {}
@@ -45,6 +48,11 @@ extension DecodingFailure: LocalizedError {
       return """
       The decoded alias value for token '\(tokenName) at path \(tokenPath) is invalid. 
       Reason: \(valueFailure.localizedDescription)
+      """
+
+    case let .invalidGradientValue(tokenName, tokenPath):
+      return """
+      The decoded value for token '\(tokenName) at path \(tokenPath) is invalid.
       """
     }
   }

--- a/Sources/DesignTokensCore/Errors/DecodingFailure.swift
+++ b/Sources/DesignTokensCore/Errors/DecodingFailure.swift
@@ -14,6 +14,9 @@ enum DecodingFailure: Error {
   /// The decoded dimension value is invalid.
   case invalidDimensionValue(tokenName: String, tokenPath: [String], valueFailure: DimensionValueFailure)
   
+  /// The decoded number value is invalid.
+  case invalidNumberValue(tokenName: String, tokenPath: [String])
+
   /// The decoded alias value is invalid.
   case invalidAliasValue(tokenName: String, tokenPath: [String], valueFailure: AliasValueFailure)
   
@@ -42,6 +45,11 @@ extension DecodingFailure: LocalizedError {
       return """
       The decoded dimension value for token '\(tokenName) at path \(tokenPath) is invalid. 
       Reason: \(valueFailure.localizedDescription)
+      """
+      
+    case let .invalidNumberValue(tokenName, tokenPath):
+      return """
+      The decoded number value for token '\(tokenName) at path \(tokenPath) is invalid. 
       """
 
     case let .invalidAliasValue(tokenName, tokenPath, valueFailure):

--- a/Sources/DesignTokensCore/Node.swift
+++ b/Sources/DesignTokensCore/Node.swift
@@ -87,7 +87,10 @@ extension Node: DecodableWithConfiguration {
       return
     }
 
-    let stringValue = try container.decode(String.self, forKey: .value)
-    self.value = try .from(stringValue, name: name, path: path, type: type)
+    self.value = try container.decode(
+      TokenValue.self,
+      forKey: .value,
+      configuration: TokenValueDecodingConfiguration(name: name, path: path, type: type)
+    )
   }
 }

--- a/Sources/DesignTokensCore/Token/GradientToken.swift
+++ b/Sources/DesignTokensCore/Token/GradientToken.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A type representing a gradient token.
+package struct GradientToken: Token {
+  /// The name of the token.
+  let name: String
+
+  /// The optional description of the token.
+  let description: String?
+
+  /// The value of the token.
+  let gradient: Gradient
+
+  /// The path to the token.
+  ///
+  /// If the token is not contained in a group, this array contains only the `name` of the token.
+  let path: Path
+
+  init(name: String, description: String? = nil, gradient: Gradient, path: Path) {
+    self.name = name
+    self.description = description
+    self.gradient = gradient
+    self.path = path
+  }
+}

--- a/Sources/DesignTokensCore/Token/NumberToken.swift
+++ b/Sources/DesignTokensCore/Token/NumberToken.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A type representing a number token.
+package struct NumberToken: Token {
+  /// The name of the token.
+  let name: String
+
+  /// The optional description of the token.
+  let description: String?
+
+  /// The value of the token.
+  let number: CGFloat
+
+  /// The path to the token.
+  ///
+  /// If the token is not contained in a group, this array contains only the `name` of the token.
+  let path: [String]
+
+  init(name: String, description: String? = nil, number: CGFloat, path: [String]) {
+    self.name = name
+    self.description = description
+    self.number = number
+    self.path = path
+  }
+}

--- a/Sources/DesignTokensCore/Token/Path.swift
+++ b/Sources/DesignTokensCore/Token/Path.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+/// The path to the token in a design token tree.
+typealias Path = [String]

--- a/Sources/DesignTokensCore/Token/TokenType.swift
+++ b/Sources/DesignTokensCore/Token/TokenType.swift
@@ -8,6 +8,9 @@ package enum TokenType: String, Decodable, CaseIterable {
   /// The `"dimension"` type.
   case dimension
 
+  /// The `"number"` type.
+  case number
+
   /// The `"gradient"` type.
   case gradient
 }

--- a/Sources/DesignTokensCore/Token/TokenType.swift
+++ b/Sources/DesignTokensCore/Token/TokenType.swift
@@ -7,4 +7,7 @@ package enum TokenType: String, Decodable, CaseIterable {
 
   /// The `"dimension"` type.
   case dimension
+
+  /// The `"gradient"` type.
+  case gradient
 }

--- a/Sources/DesignTokensCore/Token/TokenValue.swift
+++ b/Sources/DesignTokensCore/Token/TokenValue.swift
@@ -45,7 +45,7 @@ extension TokenValue {
     let stringValue = try stringValueContainer.decode(String.self)
 
     let alias = try Alias(stringValue)
-    return .alias(alias.path)
+    return .alias(alias.reference)
   }
 
   private static func decodeColor(from decoder: any Decoder, with configuration: DecodingConfiguration) throws -> TokenValue {

--- a/Sources/DesignTokensCore/Token/TokenValue.swift
+++ b/Sources/DesignTokensCore/Token/TokenValue.swift
@@ -1,58 +1,72 @@
 import Foundation
 
-package typealias Path = [String]
+typealias Path = [String]
 
 /// The possible values of a design token.
-package enum TokenValue: Equatable {
+enum TokenValue: Equatable {
   case color(Color)
   case dimension(Dimension)
   case alias(Path)
 }
 
-extension TokenValue {
-  /// Decodes the token value from its string value.
-  /// - Parameters:
-  ///   - stringValue: The string value of the token.
-  ///   - type: The type of the token.
-  /// - Returns: The decoded `TokenValue`.
-  static func from(_ stringValue: String, name: String, path: [String], type: TokenType?) throws(DecodingFailure) -> TokenValue {
+extension TokenValue: DecodableWithConfiguration {
+  init(from decoder: any Decoder, configuration: TokenValueDecodingConfiguration) throws {
     do {
-      return try attemptAliasDecoding(stringValue, name: name, path: path)
+      self = try Self.decodeAlias(from: decoder, with: configuration)
     } catch {
-      guard let type else {
-        do {
-          return try attemptAliasDecoding(stringValue, name: name, path: path)
-        } catch {
-          throw .missingType(tokenName: name, tokenPath: path)
-        }
-      }
-      
-      return try decodeValue(stringValue, of: type, name: name, path: path)
+      self = try Self.decodeValue(from: decoder, with: configuration)
     }
   }
-  
-  private static func decodeValue(_ stringValue: String, of type: TokenType, name: String, path: [String]) throws(DecodingFailure) -> TokenValue {
+}
+
+extension TokenValue {
+  private static func decodeValue(from decoder: any Decoder, with configuration: DecodingConfiguration) throws -> TokenValue {
+    guard let type = configuration.type else {
+      do {
+        return try Self.decodeAlias(from: decoder, with: configuration)
+      } catch {
+        throw DecodingFailure.missingType(tokenName: configuration.name, tokenPath: configuration.path)
+      }
+    }
+
     switch type {
     case .color:
-      do {
-        let color = try Color(stringValue)
-        return .color(color)
-      } catch {
-        throw .invalidColorValue(tokenName: name, tokenPath: path, valueFailure: error)
-      }
-      
+      return try Self.decodeColor(from: decoder, with: configuration)
+
     case .dimension:
-      do {
-        let dimension = try Dimension(stringValue)
-        return .dimension(dimension)
-      } catch {
-        throw .invalidDimensionValue(tokenName: name, tokenPath: path, valueFailure: error)
-      }
+      return try Self.decodeDimension(from: decoder, with: configuration)
     }
   }
-  
-  private static func attemptAliasDecoding(_ stringValue: String, name: String, path: [String]) throws(AliasValueFailure) -> TokenValue {
+
+  private static func decodeAlias(from decoder: any Decoder, with configuration: DecodingConfiguration) throws -> TokenValue {
+    let stringValueContainer = try decoder.singleValueContainer()
+    let stringValue = try stringValueContainer.decode(String.self)
+
     let alias = try Alias(stringValue)
     return .alias(alias.path)
+  }
+
+  private static func decodeColor(from decoder: any Decoder, with configuration: DecodingConfiguration) throws -> TokenValue {
+    let stringValueContainer = try decoder.singleValueContainer()
+    let stringValue = try stringValueContainer.decode(String.self)
+
+    do {
+      let color = try Color(stringValue)
+      return .color(color)
+    } catch {
+      throw DecodingFailure.invalidColorValue(tokenName: configuration.name, tokenPath: configuration.path, valueFailure: error)
+    }
+  }
+
+  private static func decodeDimension(from decoder: any Decoder, with configuration: DecodingConfiguration) throws -> TokenValue {
+    let stringValueContainer = try decoder.singleValueContainer()
+    let stringValue = try stringValueContainer.decode(String.self)
+
+    do {
+      let dimension = try Dimension(stringValue)
+      return .dimension(dimension)
+    } catch {
+      throw DecodingFailure.invalidDimensionValue(tokenName: configuration.name, tokenPath: configuration.path, valueFailure: error)
+    }
   }
 }

--- a/Sources/DesignTokensCore/Token/TokenValue.swift
+++ b/Sources/DesignTokensCore/Token/TokenValue.swift
@@ -1,12 +1,11 @@
 import Foundation
 
-typealias Path = [String]
-
 /// The possible values of a design token.
 enum TokenValue: Equatable {
   case color(Color)
   case dimension(Dimension)
   case alias(Path)
+  case gradient(Gradient)
 }
 
 extension TokenValue: DecodableWithConfiguration {
@@ -35,6 +34,9 @@ extension TokenValue {
 
     case .dimension:
       return try Self.decodeDimension(from: decoder, with: configuration)
+
+    case .gradient:
+      return try Self.decodeGradient(from: decoder, with: configuration)
     }
   }
 
@@ -67,6 +69,17 @@ extension TokenValue {
       return .dimension(dimension)
     } catch {
       throw DecodingFailure.invalidDimensionValue(tokenName: configuration.name, tokenPath: configuration.path, valueFailure: error)
+    }
+  }
+
+  private static func decodeGradient(from decoder: any Decoder, with configuration: DecodingConfiguration) throws -> TokenValue {
+    let container = try decoder.singleValueContainer()
+
+    do {
+      let gradient = try container.decode(Gradient.self)
+      return .gradient(gradient)
+    } catch {
+      throw DecodingFailure.invalidGradientValue(tokenName: configuration.name, tokenPath: configuration.path)
     }
   }
 }

--- a/Sources/DesignTokensCore/Token/TokenValue.swift
+++ b/Sources/DesignTokensCore/Token/TokenValue.swift
@@ -4,6 +4,7 @@ import Foundation
 enum TokenValue: Equatable {
   case color(Color)
   case dimension(Dimension)
+  case number(CGFloat)
   case alias(Path)
   case gradient(Gradient)
 }
@@ -34,6 +35,9 @@ extension TokenValue {
 
     case .dimension:
       return try Self.decodeDimension(from: decoder, with: configuration)
+
+    case .number:
+      return try Self.decodeNumber(from: decoder, with: configuration)
 
     case .gradient:
       return try Self.decodeGradient(from: decoder, with: configuration)
@@ -69,6 +73,17 @@ extension TokenValue {
       return .dimension(dimension)
     } catch {
       throw DecodingFailure.invalidDimensionValue(tokenName: configuration.name, tokenPath: configuration.path, valueFailure: error)
+    }
+  }
+
+  private static func decodeNumber(from decoder: any Decoder, with configuration: DecodingConfiguration) throws -> TokenValue {
+    let container = try decoder.singleValueContainer()
+
+    do {
+      let value = try container.decode(CGFloat.self)
+      return .number(value)
+    } catch {
+      throw DecodingFailure.invalidNumberValue(tokenName: configuration.name, tokenPath: configuration.path)
     }
   }
 

--- a/Sources/DesignTokensCore/TreeReducer.swift
+++ b/Sources/DesignTokensCore/TreeReducer.swift
@@ -19,30 +19,31 @@ package struct TreeReducer {
   /// - Returns: A tuple of `[ColorToken]`, and `[AliasToken]` that reference color tokens.
   package func colors() -> ([ColorToken], [AliasToken]) {
     let tokens = colorTokens()
-
-    let aliases = aliasTokens { alias in
-      tokens.contains { token in
-        token.path == alias.reference
-      }
-    }
+    let aliases = aliasTokens(for: tokens)
 
     return (tokens, aliases)
   }
 
   /// Reduces the trees into all dimension tokens, and matching aliases.
-  /// - Returns: A tuple of `[DimensionToken]`, and `[AliasToken]` that reference color tokens.
+  /// - Returns: A tuple of `[DimensionToken]`, and `[AliasToken]` that reference dimension tokens.
   package func dimensions() -> ([DimensionToken], [AliasToken]) {
     let tokens = dimensionTokens()
-
-    let aliases = aliasTokens { alias in
-      tokens.contains { token in
-        token.path == alias.reference
-      }
-    }
+    let aliases = aliasTokens(for: tokens)
 
     return (tokens, aliases)
   }
 
+  /// Reduces the trees into all number tokens, and matching aliases.
+  /// - Returns: A tuple of `[NumberToken]`, and `[AliasToken]` that reference number tokens.
+  package func numbers() -> ([NumberToken], [AliasToken]) {
+    let tokens = numberTokens()
+    let aliases = aliasTokens(for: tokens)
+
+    return (tokens, aliases)
+  }
+
+  /// Reduces the trees into all gradient tokens.
+  /// - Returns: An array of `NumberToken`.
   package func gradients() -> [GradientToken] {
     // TODO: Do gradients support aliases?
     gradientTokens()
@@ -70,6 +71,17 @@ package struct TreeReducer {
     }
   }
 
+  private func numberTokens() -> [NumberToken] {
+    trees.reduce(into: []) { result, tree in
+      tree.root.depthFirstTraversal { node in
+        if case let .number(number) = node.value {
+          let token = NumberToken(name: node.name, description: node.description, number: number, path: node.path)
+          result.append(token)
+        }
+      }
+    }
+  }
+
   private func gradientTokens() -> [GradientToken] {
     trees.reduce(into: []) { result, tree in
       tree.root.depthFirstTraversal { node in
@@ -77,6 +89,14 @@ package struct TreeReducer {
           let token = GradientToken(name: node.name, description: node.description, gradient: gradient, path: node.path)
           result.append(token)
         }
+      }
+    }
+  }
+
+  private func aliasTokens<T>(for sequence: [T]) -> [AliasToken] where T: Token {
+    aliasTokens { alias in
+      sequence.contains { token in
+        token.path == alias.reference
       }
     }
   }

--- a/Sources/DesignTokensCore/TreeReducer.swift
+++ b/Sources/DesignTokensCore/TreeReducer.swift
@@ -43,7 +43,12 @@ package struct TreeReducer {
     return (tokens, aliases)
   }
 
-  func colorTokens() -> [ColorToken] {
+  package func gradients() -> [GradientToken] {
+    // TODO: Do gradients support aliases?
+    gradientTokens()
+  }
+
+  private func colorTokens() -> [ColorToken] {
     trees.reduce(into: []) { result, tree in
       tree.root.depthFirstTraversal { node in
         if case let .color(color) = node.value {
@@ -54,7 +59,7 @@ package struct TreeReducer {
     }
   }
 
-  func dimensionTokens() -> [DimensionToken] {
+  private func dimensionTokens() -> [DimensionToken] {
     trees.reduce(into: []) { result, tree in
       tree.root.depthFirstTraversal { node in
         if case let .dimension(dimension) = node.value {
@@ -65,7 +70,18 @@ package struct TreeReducer {
     }
   }
 
-  func aliasTokens(where predicate: (AliasToken) -> Bool) -> [AliasToken] {
+  private func gradientTokens() -> [GradientToken] {
+    trees.reduce(into: []) { result, tree in
+      tree.root.depthFirstTraversal { node in
+        if case let .gradient(gradient) = node.value {
+          let token = GradientToken(name: node.name, description: node.description, gradient: gradient, path: node.path)
+          result.append(token)
+        }
+      }
+    }
+  }
+
+  private func aliasTokens(where predicate: (AliasToken) -> Bool) -> [AliasToken] {
     trees.reduce(into: []) { result, tree in
       tree.root.depthFirstTraversal { node in
         if case let .alias(path) = node.value {

--- a/Sources/DesignTokensCore/Type/Alias.swift
+++ b/Sources/DesignTokensCore/Type/Alias.swift
@@ -7,9 +7,13 @@ struct Alias {
   // MARK: - Stored Properties
 
   /// The path to the referenced token.
-  let reference: [String]
+  let reference: Path
 
   // MARK: - Init
+
+  init(reference: Path) {
+    self.reference = reference
+  }
 
   init(_ stringValue: String) throws(AliasValueFailure) {
     let allowedNameCharacters: CharacterClass = .word.union(.digit).union(.generalCategory(.dashPunctuation))

--- a/Sources/DesignTokensCore/Type/Alias.swift
+++ b/Sources/DesignTokensCore/Type/Alias.swift
@@ -7,7 +7,7 @@ struct Alias {
   // MARK: - Stored Properties
 
   /// The path to the referenced token.
-  let path: [String]
+  let reference: [String]
 
   // MARK: - Init
 
@@ -34,6 +34,17 @@ struct Alias {
     }
     
     let (_, value) = match.output
-    self.path = value.components(separatedBy: ".")
+    self.reference = value.components(separatedBy: ".")
   }
 }
+
+extension Alias: Decodable {
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let stringValue = try container.decode(String.self)
+    
+    try self.init(stringValue)
+  }
+}
+
+extension Alias: Equatable {}

--- a/Sources/DesignTokensCore/Type/AliasOr.swift
+++ b/Sources/DesignTokensCore/Type/AliasOr.swift
@@ -3,7 +3,7 @@ import Foundation
 // TODO: Check if we can handle an enum with Stencil
 
 /// A type that can contain either a token value, or an alias, but not both.
-struct AliasOr<Value> {
+struct AliasOr<Value>: Sendable where Value: Sendable {
 
   // MARK: - Stored Properties
 
@@ -21,6 +21,18 @@ struct AliasOr<Value> {
   init(alias: Alias) {
     self.value = nil
     self.alias = alias
+  }
+
+  static func alias(_ reference: Path) -> AliasOr<Value> {
+    AliasOr(alias: Alias(reference: reference))
+  }
+
+  static func color(_ value: Color) -> AliasOr<Color> {
+    AliasOr<Color>(value: value)
+  }
+
+  static func float(_ value: CGFloat) -> AliasOr<CGFloat> {
+    AliasOr<CGFloat>(value: value)
   }
 }
 

--- a/Sources/DesignTokensCore/Type/AliasOr.swift
+++ b/Sources/DesignTokensCore/Type/AliasOr.swift
@@ -1,38 +1,12 @@
 import Foundation
 
-// TODO: Check if we can handle an enum with Stencil
-
-/// A type that can contain either a token value, or an alias, but not both.
-struct AliasOr<Value>: Sendable where Value: Sendable {
-
-  // MARK: - Stored Properties
-
-  let value: Value?
-
-  let alias: Alias?
-
-  // MARK: - Init
-
-  init(value: Value) {
-    self.value = value
-    self.alias = nil
-  }
-
-  init(alias: Alias) {
-    self.value = nil
-    self.alias = alias
-  }
+/// A type contains either a token value, or an alias.
+enum AliasOr<Value>: Sendable where Value: Sendable {
+  case value(Value)
+  case alias(Alias)
 
   static func alias(_ reference: Path) -> AliasOr<Value> {
-    AliasOr(alias: Alias(reference: reference))
-  }
-
-  static func color(_ value: Color) -> AliasOr<Color> {
-    AliasOr<Color>(value: value)
-  }
-
-  static func float(_ value: CGFloat) -> AliasOr<CGFloat> {
-    AliasOr<CGFloat>(value: value)
+    AliasOr.alias(Alias(reference: reference))
   }
 }
 
@@ -41,11 +15,11 @@ extension AliasOr: Decodable where Value: Decodable {
     let container = try decoder.singleValueContainer()
 
     do {
-      value = try container.decode(Value.self)
-      alias = nil
+      let value = try container.decode(Value.self)
+      self = .value(value)
     } catch {
-      value = nil
-      alias = try container.decode(Alias.self)
+      let alias = try container.decode(Alias.self)
+      self = .alias(alias)
     }
   }
 }

--- a/Sources/DesignTokensCore/Type/AliasOr.swift
+++ b/Sources/DesignTokensCore/Type/AliasOr.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+// TODO: Check if we can handle an enum with Stencil
+
+/// A type that can contain either a token value, or an alias, but not both.
+struct AliasOr<Value> {
+
+  // MARK: - Stored Properties
+
+  let value: Value?
+
+  let alias: Alias?
+
+  // MARK: - Init
+
+  init(value: Value) {
+    self.value = value
+    self.alias = nil
+  }
+
+  init(alias: Alias) {
+    self.value = nil
+    self.alias = alias
+  }
+}
+
+extension AliasOr: Decodable where Value: Decodable {
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+
+    do {
+      value = try container.decode(Value.self)
+      alias = nil
+    } catch {
+      value = nil
+      alias = try container.decode(Alias.self)
+    }
+  }
+}
+
+extension AliasOr: Equatable where Value: Equatable {}

--- a/Sources/DesignTokensCore/Type/Color.swift
+++ b/Sources/DesignTokensCore/Type/Color.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type representing a color.
-package struct Color {
+struct Color {
 
   // MARK: - Stored Properties
   

--- a/Sources/DesignTokensCore/Type/Color.swift
+++ b/Sources/DesignTokensCore/Type/Color.swift
@@ -66,3 +66,12 @@ struct Color {
 }
 
 extension Color: Equatable {}
+
+extension Color: Decodable {
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let stringValue = try container.decode(String.self)
+
+    try self.init(stringValue)
+  }
+}

--- a/Sources/DesignTokensCore/Type/Color.swift
+++ b/Sources/DesignTokensCore/Type/Color.swift
@@ -66,6 +66,8 @@ struct Color {
 }
 
 extension Color {
+  static let blue = Color(red: 0.0, green: 0.0, blue: 1.0, alpha: 1.0)
+  static let red = Color(red: 1.0, green: 0.0, blue: 0.0, alpha: 1.0)
   static let white = Color(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
 }
 

--- a/Sources/DesignTokensCore/Type/Gradient.swift
+++ b/Sources/DesignTokensCore/Type/Gradient.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A type representing a gradient.
+struct Gradient {
+  /// A type representing the stops of a gradient.
+  struct Stop {
+    /// The color of the stop in the gradient.
+    let color: Color
+
+    /// The position of the stop in the gradient.
+    let position: CGFloat
+  }
+
+  /// The stops of the gradient.
+  let stops: [Stop]
+}
+
+extension Gradient: Decodable {
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let stops = try container.decode([Stop].self)
+
+    self.stops = stops
+  }
+}
+
+extension Gradient: Equatable {}
+
+extension Gradient.Stop: Decodable {}
+
+extension Gradient.Stop: Equatable {}

--- a/Sources/DesignTokensCore/Type/Gradient.swift
+++ b/Sources/DesignTokensCore/Type/Gradient.swift
@@ -5,10 +5,10 @@ struct Gradient {
   /// A type representing the stops of a gradient.
   struct Stop {
     /// The color of the stop in the gradient.
-    let color: Color
+    let color: AliasOr<Color>
 
     /// The position of the stop in the gradient.
-    let position: CGFloat
+    let position: AliasOr<CGFloat>
   }
 
   /// The stops of the gradient.

--- a/Sources/DesignTokensCore/Type/Gradient.swift
+++ b/Sources/DesignTokensCore/Type/Gradient.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// A type representing a gradient.
-struct Gradient {
+struct Gradient: Sendable {
   /// A type representing the stops of a gradient.
-  struct Stop {
+  struct Stop: Sendable {
     /// The color of the stop in the gradient.
     let color: AliasOr<Color>
 
@@ -13,6 +13,15 @@ struct Gradient {
 
   /// The stops of the gradient.
   let stops: [Stop]
+}
+
+extension Gradient {
+  static let blueToRed = Gradient(
+    stops: [
+      Gradient.Stop(color: .color(.blue), position: .float(0)),
+      Gradient.Stop(color: .color(.red), position: .float(1)),
+    ]
+  )
 }
 
 extension Gradient: Decodable {

--- a/Sources/DesignTokensCore/Type/Gradient.swift
+++ b/Sources/DesignTokensCore/Type/Gradient.swift
@@ -18,8 +18,8 @@ struct Gradient: Sendable {
 extension Gradient {
   static let blueToRed = Gradient(
     stops: [
-      Gradient.Stop(color: .color(.blue), position: .float(0)),
-      Gradient.Stop(color: .color(.red), position: .float(1)),
+      Gradient.Stop(color: .value(.blue), position: .value(0)),
+      Gradient.Stop(color: .value(.red), position: .value(1)),
     ]
   )
 }

--- a/Sources/DesignTokensGenerator/Configuration/Configuration.swift
+++ b/Sources/DesignTokensGenerator/Configuration/Configuration.swift
@@ -8,6 +8,7 @@ struct Configuration: ConfigurationProtocol, Equatable {
     case colorConfiguration = "colors"
     case dimensionConfiguration = "dimensions"
     case gradientConfiguration = "gradients"
+    case numberConfiguration = "numbers"
   }
   
   // MARK: - Stored Properties
@@ -27,6 +28,9 @@ struct Configuration: ConfigurationProtocol, Equatable {
   /// The configuration for the gradient tokens.
   private(set) var gradientConfiguration: GradientConfiguration?
 
+  /// The configuration for the number tokens.
+  private(set) var numberConfiguration: NumberConfiguration?
+
   // MARK: - Init
 
   init() {
@@ -35,6 +39,7 @@ struct Configuration: ConfigurationProtocol, Equatable {
     self.colorConfiguration = nil
     self.dimensionConfiguration = nil
     self.gradientConfiguration = nil
+    self.numberConfiguration = nil
   }
   
   // MARK: - Functions
@@ -167,6 +172,7 @@ extension Configuration {
     self.colorConfiguration = try container.decodeIfPresent(ColorConfiguration.self, forKey: .colorConfiguration)
     self.dimensionConfiguration = try container.decodeIfPresent(DimensionConfiguration.self, forKey: .dimensionConfiguration)
     self.gradientConfiguration = try container.decodeIfPresent(GradientConfiguration.self, forKey: .gradientConfiguration)
+    self.numberConfiguration = try container.decodeIfPresent(NumberConfiguration.self, forKey: .numberConfiguration)
   }
 }
 

--- a/Sources/DesignTokensGenerator/Configuration/Configuration.swift
+++ b/Sources/DesignTokensGenerator/Configuration/Configuration.swift
@@ -7,6 +7,7 @@ struct Configuration: ConfigurationProtocol, Equatable {
     case outputPath = "output"
     case colorConfiguration = "colors"
     case dimensionConfiguration = "dimensions"
+    case gradientConfiguration = "gradients"
   }
   
   // MARK: - Stored Properties
@@ -23,6 +24,9 @@ struct Configuration: ConfigurationProtocol, Equatable {
   /// The configuration for the dimension tokens.
   private(set) var dimensionConfiguration: DimensionConfiguration?
 
+  /// The configuration for the gradient tokens.
+  private(set) var gradientConfiguration: GradientConfiguration?
+
   // MARK: - Init
 
   init() {
@@ -30,6 +34,7 @@ struct Configuration: ConfigurationProtocol, Equatable {
     self.outputPath = nil
     self.colorConfiguration = nil
     self.dimensionConfiguration = nil
+    self.gradientConfiguration = nil
   }
   
   // MARK: - Functions
@@ -81,14 +86,6 @@ struct Configuration: ConfigurationProtocol, Equatable {
     color(ColorConfiguration(inputPaths: [inputPath], outputPath: outputPath, formats: formats))
   }
 
-  /// Sets the configuration for the dimension tokens.
-  /// - Parameters:
-  ///   - path: The path of the directory where the output will be generated.
-  /// - Returns: The output configuration with a new dimension configuration.
-  func dimension(inputPath: String, outputPath: String? = nil) -> Configuration {
-    dimension(DimensionConfiguration(inputPaths: [inputPath], outputPath: outputPath))
-  }
-  
   /// Sets the configuration for the color tokens.
   /// - Parameters:
   ///   - inputPaths: The path of the input files.
@@ -101,11 +98,36 @@ struct Configuration: ConfigurationProtocol, Equatable {
 
   /// Sets the configuration for the dimension tokens.
   /// - Parameters:
+  ///   - path: The path of the directory where the output will be generated.
+  /// - Returns: The output configuration with a new dimension configuration.
+  func dimension(inputPath: String, outputPath: String? = nil) -> Configuration {
+    dimension(DimensionConfiguration(inputPaths: [inputPath], outputPath: outputPath))
+  }
+
+  /// Sets the configuration for the dimension tokens.
+  /// - Parameters:
   ///   - inputPaths: The path of the input files.
   ///   - outputPath: The path of the directory where the output will be generated.
   /// - Returns: The output configuration with a new dimension configuration.
   func dimension(inputPaths: [String]? = nil , outputPath: String? = nil) -> Configuration {
     dimension(DimensionConfiguration(inputPaths: inputPaths, outputPath: outputPath))
+  }
+
+  /// Sets the configuration for the gradient tokens.
+  /// - Parameters:
+  ///   - path: The path of the directory where the output will be generated.
+  /// - Returns: The output configuration with a new dimension configuration.
+  func gradient(inputPath: String, outputPath: String? = nil) -> Configuration {
+    gradient(GradientConfiguration(inputPaths: [inputPath], outputPath: outputPath))
+  }
+
+  /// Sets the configuration for the gradient tokens.
+  /// - Parameters:
+  ///   - inputPaths: The path of the input files.
+  ///   - outputPath: The path of the directory where the output will be generated.
+  /// - Returns: The output configuration with a new dimension configuration.
+  func gradient(inputPaths: [String]? = nil , outputPath: String? = nil) -> Configuration {
+    gradient(GradientConfiguration(inputPaths: inputPaths, outputPath: outputPath))
   }
   
   private func color(_ colorConfiguration: ColorConfiguration) -> Configuration {
@@ -117,6 +139,12 @@ struct Configuration: ConfigurationProtocol, Equatable {
   private func dimension(_ dimensionConfiguration: DimensionConfiguration) -> Configuration {
     var configuration = self
     configuration.dimensionConfiguration = dimensionConfiguration
+    return configuration
+  }
+  
+  private func gradient(_ gradientConfiguration: GradientConfiguration) -> Configuration {
+    var configuration = self
+    configuration.gradientConfiguration = gradientConfiguration
     return configuration
   }
 }
@@ -138,6 +166,7 @@ extension Configuration {
     self.outputPath = try container.decodeIfPresent(String.self, forKey: .outputPath)
     self.colorConfiguration = try container.decodeIfPresent(ColorConfiguration.self, forKey: .colorConfiguration)
     self.dimensionConfiguration = try container.decodeIfPresent(DimensionConfiguration.self, forKey: .dimensionConfiguration)
+    self.gradientConfiguration = try container.decodeIfPresent(GradientConfiguration.self, forKey: .gradientConfiguration)
   }
 }
 

--- a/Sources/DesignTokensGenerator/Configuration/Configuration.swift
+++ b/Sources/DesignTokensGenerator/Configuration/Configuration.swift
@@ -118,6 +118,23 @@ struct Configuration: ConfigurationProtocol, Equatable {
     dimension(DimensionConfiguration(inputPaths: inputPaths, outputPath: outputPath))
   }
 
+  /// Sets the configuration for the number tokens.
+  /// - Parameters:
+  ///   - path: The path of the directory where the output will be generated.
+  /// - Returns: The output configuration with a new number configuration.
+  func number(inputPath: String, outputPath: String? = nil) -> Configuration {
+    number(NumberConfiguration(inputPaths: [inputPath], outputPath: outputPath))
+  }
+
+  /// Sets the configuration for the number tokens.
+  /// - Parameters:
+  ///   - inputPaths: The path of the input files.
+  ///   - outputPath: The path of the directory where the output will be generated.
+  /// - Returns: The output configuration with a new number configuration.
+  func number(inputPaths: [String]? = nil , outputPath: String? = nil) -> Configuration {
+    number(NumberConfiguration(inputPaths: inputPaths, outputPath: outputPath))
+  }
+
   /// Sets the configuration for the gradient tokens.
   /// - Parameters:
   ///   - path: The path of the directory where the output will be generated.
@@ -144,6 +161,12 @@ struct Configuration: ConfigurationProtocol, Equatable {
   private func dimension(_ dimensionConfiguration: DimensionConfiguration) -> Configuration {
     var configuration = self
     configuration.dimensionConfiguration = dimensionConfiguration
+    return configuration
+  }
+  
+  private func number(_ numberConfiguration: NumberConfiguration) -> Configuration {
+    var configuration = self
+    configuration.numberConfiguration = numberConfiguration
     return configuration
   }
   

--- a/Sources/DesignTokensGenerator/Configuration/ConfigurationValidator.swift
+++ b/Sources/DesignTokensGenerator/Configuration/ConfigurationValidator.swift
@@ -7,6 +7,9 @@ enum ConfigurationValidationFailure: Error {
   
   /// No output has been provided in the configuration.
   case noOutputProvided
+
+  /// The gradient configuration requires a number configuration to be set.
+  case gradientConfigurationRequiresNumberConfiguration
 }
 
 /// An object that validates the given `Configuration`.
@@ -30,6 +33,7 @@ struct ConfigurationValidator {
   func validate() throws(ConfigurationValidationFailure) {
     try validateInputs()
     try validateOutputs()
+    try validateConfigurations()
   }
   
   private func validateInputs() throws(ConfigurationValidationFailure) {
@@ -61,6 +65,12 @@ struct ConfigurationValidator {
     
     if !hasOutput {
       throw .noOutputProvided
+    }
+  }
+
+  private func validateConfigurations() throws(ConfigurationValidationFailure) {
+    if configuration.gradientConfiguration != nil && configuration.numberConfiguration == nil {
+      throw .gradientConfigurationRequiresNumberConfiguration
     }
   }
 }

--- a/Sources/DesignTokensGenerator/Configuration/GradientConfiguration.swift
+++ b/Sources/DesignTokensGenerator/Configuration/GradientConfiguration.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// A type representing the output configuration for gradient tokens.
+struct GradientConfiguration: ConfigurationProtocol, Equatable {
+  enum CodingKeys: String, CodingKey {
+    case inputPaths = "input"
+    case outputPath = "output"
+  }
+  
+  // MARK: - Stored Properties
+  
+  private(set) var inputPaths: [String]?
+
+  private(set) var outputPath: String?
+  
+  // MARK: - Init
+
+  init(inputPath: String, outputPath: String?) {
+    self.inputPaths = [inputPath]
+    self.outputPath = outputPath
+  }
+
+  init(inputPaths: [String]?, outputPath: String?) {
+    self.inputPaths = inputPaths
+    self.outputPath = outputPath
+  }
+}
+
+extension GradientConfiguration {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    do {
+      if let inputPath = try container.decodeIfPresent(String.self, forKey: .inputPaths) {
+        self.inputPaths = [inputPath]
+      }
+    } catch DecodingError.typeMismatch {
+      if let inputPaths = try container.decodeIfPresent([String].self, forKey: .inputPaths) {
+        self.inputPaths = inputPaths
+      }
+    }
+
+    self.outputPath = try container.decodeIfPresent(String.self, forKey: .outputPath)
+  }
+}

--- a/Sources/DesignTokensGenerator/Configuration/NumberConfiguration.swift
+++ b/Sources/DesignTokensGenerator/Configuration/NumberConfiguration.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// A type representing the output configuration for number tokens.
+struct NumberConfiguration: ConfigurationProtocol, Equatable {
+  enum CodingKeys: String, CodingKey {
+    case inputPaths = "input"
+    case outputPath = "output"
+  }
+  
+  // MARK: - Stored Properties
+  
+  private(set) var inputPaths: [String]?
+
+  private(set) var outputPath: String?
+  
+  // MARK: - Init
+
+  init(inputPath: String, outputPath: String?) {
+    self.inputPaths = [inputPath]
+    self.outputPath = outputPath
+  }
+
+  init(inputPaths: [String]?, outputPath: String?) {
+    self.inputPaths = inputPaths
+    self.outputPath = outputPath
+  }
+}
+
+extension NumberConfiguration {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    do {
+      if let inputPath = try container.decodeIfPresent(String.self, forKey: .inputPaths) {
+        self.inputPaths = [inputPath]
+      }
+    } catch DecodingError.typeMismatch {
+      if let inputPaths = try container.decodeIfPresent([String].self, forKey: .inputPaths) {
+        self.inputPaths = inputPaths
+      }
+    }
+
+    self.outputPath = try container.decodeIfPresent(String.self, forKey: .outputPath)
+  }
+}

--- a/Sources/DesignTokensGenerator/Constants.swift
+++ b/Sources/DesignTokensGenerator/Constants.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-package let defaultConfigurationFileName = "design-tokens-configuration.json"
+package let defaultConfigurationFileName = "design-tokens-configuration"

--- a/Sources/DesignTokensGenerator/Generators/ColorSourceCodeGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/ColorSourceCodeGenerator.swift
@@ -2,7 +2,7 @@ import DesignTokensCore
 import Foundation
 import Stencil
 
-/// The object that generates source code for the color tokens.
+/// The object that generates source code for color tokens.
 struct ColorSourceCodeGenerator: SourceCodeGenerator {
   
   // MARK: - Stored Properties
@@ -44,11 +44,11 @@ struct ColorSourceCodeGenerator: SourceCodeGenerator {
     switch format {
     case .swiftUI:
       let content = try environment.renderTemplate(name: "color+swiftui.stencil", context: context)
-      return SourceCodeFile(name: "Color+DesignTokens.swift", content: content)
+      return SourceCodeFile(name: "Color+SwiftUI+DesignTokens.swift", content: content)
 
     case .uiKit:
       let content = try environment.renderTemplate(name: "color+uikit.stencil", context: context)
-      return SourceCodeFile(name: "UIColor+DesignTokens.swift", content: content)
+      return SourceCodeFile(name: "Color+UIKit+DesignTokens.swift", content: content)
     }
   }
 }

--- a/Sources/DesignTokensGenerator/Generators/DimensionSourceCodeGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/DimensionSourceCodeGenerator.swift
@@ -2,7 +2,7 @@ import DesignTokensCore
 import Foundation
 import Stencil
 
-/// The object that generates source code for the dimension tokens.
+/// The object that generates source code for dimension tokens.
 struct DimensionSourceCodeGenerator: SourceCodeGenerator {
   
   // MARK: - Stored Properties
@@ -38,6 +38,6 @@ struct DimensionSourceCodeGenerator: SourceCodeGenerator {
     ]
 
     let content = try environment.renderTemplate(name: "dimension+foundation.stencil", context: context)
-    return SourceCodeFile(name: "CGFloat+DesignToken.swift", content: content)
+    return SourceCodeFile(name: "Dimension+DesignTokens.swift", content: content)
   }
 }

--- a/Sources/DesignTokensGenerator/Generators/GradientSourceCodeGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/GradientSourceCodeGenerator.swift
@@ -2,16 +2,13 @@ import DesignTokensCore
 import Foundation
 import Stencil
 
-/// The object that generates source code for the dimension tokens.
-struct DimensionSourceCodeGenerator: SourceCodeGenerator {
-  
+/// The object that generates source code for the gradient tokens.
+struct GradientSourceCodeGenerator: SourceCodeGenerator {
+
   // MARK: - Stored Properties
   
-  /// The dimension tokens.
-  let tokens: [DimensionToken]
-  
-  /// The aliases for the tokens.
-  let aliases: [AliasToken]
+  /// The gradient tokens.
+  let tokens: [GradientToken]
 
   // MARK: - Functions
   
@@ -23,21 +20,19 @@ struct DimensionSourceCodeGenerator: SourceCodeGenerator {
       return []
     }
 
-    let file = try generate(tokens, aliases: aliases, in: environment)
+    let file = try generate(tokens, in: environment)
     return [file]
   }
 
   private func generate(
-    _ tokens: [DesignTokensCore.DimensionToken],
-    aliases: [DesignTokensCore.AliasToken],
+    _ tokens: [DesignTokensCore.GradientToken],
     in environment: Stencil.Environment
   ) throws -> SourceCodeFile {
     let context: [String: Any] = [
       "tokens": tokens,
-      "aliases": aliases,
     ]
 
-    let content = try environment.renderTemplate(name: "dimension+foundation.stencil", context: context)
-    return SourceCodeFile(name: "CGFloat+DesignToken.swift", content: content)
+    let content = try environment.renderTemplate(name: "gradient+swiftui.stencil", context: context)
+    return SourceCodeFile(name: "Gradient+DesignToken.swift", content: content)
   }
 }

--- a/Sources/DesignTokensGenerator/Generators/GradientSourceCodeGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/GradientSourceCodeGenerator.swift
@@ -2,7 +2,7 @@ import DesignTokensCore
 import Foundation
 import Stencil
 
-/// The object that generates source code for the gradient tokens.
+/// The object that generates source code for gradient tokens.
 struct GradientSourceCodeGenerator: SourceCodeGenerator {
 
   // MARK: - Stored Properties
@@ -33,6 +33,6 @@ struct GradientSourceCodeGenerator: SourceCodeGenerator {
     ]
 
     let content = try environment.renderTemplate(name: "gradient+swiftui.stencil", context: context)
-    return SourceCodeFile(name: "Gradient+DesignToken.swift", content: content)
+    return SourceCodeFile(name: "Gradient+SwiftUI+DesignTokens.swift", content: content)
   }
 }

--- a/Sources/DesignTokensGenerator/Generators/NumberSourceCodeGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/NumberSourceCodeGenerator.swift
@@ -1,0 +1,43 @@
+import DesignTokensCore
+import Foundation
+import Stencil
+
+/// The object that generates source code for number tokens.
+struct NumberSourceCodeGenerator: SourceCodeGenerator {
+
+  // MARK: - Stored Properties
+  
+  /// The number tokens.
+  let tokens: [NumberToken]
+
+  /// The aliases for the tokens.
+  let aliases: [AliasToken]
+
+  // MARK: - Functions
+  
+  /// Generates the dimensions source code with the passed `Stencil` environment.
+  /// - Parameter environment: The `Stencil` environment used to generate the source code.
+  /// - Returns: The list of source code files generated.
+  func generate(with environment: Stencil.Environment) throws -> [SourceCodeFile] {
+    guard !tokens.isEmpty else {
+      return []
+    }
+
+    let file = try generate(tokens, aliases: aliases, in: environment)
+    return [file]
+  }
+
+  private func generate(
+    _ tokens: [DesignTokensCore.NumberToken],
+    aliases: [DesignTokensCore.AliasToken],
+    in environment: Stencil.Environment
+  ) throws -> SourceCodeFile {
+    let context: [String: Any] = [
+      "tokens": tokens,
+      "aliases": aliases,
+    ]
+
+    let content = try environment.renderTemplate(name: "number+foundation.stencil", context: context)
+    return SourceCodeFile(name: "Number+DesignTokens.swift", content: content)
+  }
+}

--- a/Sources/DesignTokensGenerator/Generators/OutputGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/OutputGenerator.swift
@@ -164,10 +164,8 @@ package struct OutputGenerator {
     
     let outputURL = outputURL(with: configurationLocator, for: outputPath)
 
-    let tokens: [GradientToken] = trees.reduce(into: []) { result, tree in
-      let tokens = tree.gradientTokens()
-      result.append(contentsOf: tokens)
-    }
+    let reducer = TreeReducer(trees: trees)
+    let tokens = reducer.gradients()
 
     let sourceCodeGenerator = GradientSourceCodeGenerator(tokens: tokens)
     let files = try sourceCodeGenerator.generate(with: StencilEnvironmentProvider.swift())

--- a/Sources/DesignTokensGenerator/Resources/color+swiftui.stencil
+++ b/Sources/DesignTokensGenerator/Resources/color+swiftui.stencil
@@ -5,7 +5,7 @@ import SwiftUI
 
 {% import "common.stencil" %}
 {% set tokenType %}Color{% endset %}
-{% macro colorValue color %}{{tokenType}}(red: {{ color.red }}, blue: {{ color.blue }}, green: {{ color.green }}, opacity: {{ color.alpha }}){% endmacro %}
+{% macro colorValue color %}{{tokenType}}(red: {{ color.red }}, green: {{ color.green }}, blue: {{ color.blue }}, opacity: {{ color.alpha }}){% endmacro %}
 {% macro tokensBlock tokens %}
   {% for token in tokens %}
   {% if token.description %}

--- a/Sources/DesignTokensGenerator/Resources/color+uikit.stencil
+++ b/Sources/DesignTokensGenerator/Resources/color+uikit.stencil
@@ -5,7 +5,7 @@ import UIKit
 
 {% import "common.stencil" %}
 {% set tokenType %}UIColor{% endset %}
-{% macro colorValue color %}{{tokenType}}(red: {{ color.red }}, blue: {{ color.blue }}, green: {{ color.green }}, alpha: {{ color.alpha }}){% endmacro %}
+{% macro colorValue color %}{{tokenType}}(red: {{ color.red }}, green: {{ color.green }}, blue: {{ color.blue }}, alpha: {{ color.alpha }}){% endmacro %}
 {% macro tokensBlock tokens %}
   {% for token in tokens %}
   {% if token.description %}

--- a/Sources/DesignTokensGenerator/Resources/color+uikit.stencil
+++ b/Sources/DesignTokensGenerator/Resources/color+uikit.stencil
@@ -5,14 +5,13 @@ import UIKit
 
 {% import "common.stencil" %}
 {% set tokenType %}UIColor{% endset %}
-{% macro colorValue color %}{{tokenType}}(red: {{ color.red }}, green: {{ color.green }}, blue: {{ color.blue }}, alpha: {{ color.alpha }}){% endmacro %}
 {% macro tokensBlock tokens %}
   {% for token in tokens %}
   {% if token.description %}
   /// {{ token.description }}
   {% endif %}
   {% set tokenName %}{{ token.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords }}{% endset %}
-  static let {{ tokenName }} = {%+  call colorValue token.color +%}
+  static let {{ tokenName }} = {%+  call uiKitColor token.color +%}
   {% endfor %}
 {% endmacro %}
 

--- a/Sources/DesignTokensGenerator/Resources/common.stencil
+++ b/Sources/DesignTokensGenerator/Resources/common.stencil
@@ -3,7 +3,7 @@
 {% macro aliasesBlock aliases aliasType %}
   {% for alias in aliases %}
   {% set aliasName %}{{alias.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  public static var {{aliasName}}: {{aliasType}} { {% call referenceName alias %} }
+  public static var {{aliasName}}: {{aliasType}} { {%+ call referenceName alias %} }
   {% endfor %}
 {% endmacro %}
 

--- a/Sources/DesignTokensGenerator/Resources/common.stencil
+++ b/Sources/DesignTokensGenerator/Resources/common.stencil
@@ -1,8 +1,9 @@
+{% macro referenceName alias %}{{alias.reference|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endmacro %}
+
 {% macro aliasesBlock aliases aliasType %}
   {% for alias in aliases %}
   {% set aliasName %}{{alias.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set referenceName %}{{alias.reference|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  public static var {{aliasName}}: {{aliasType}} { {{referenceName}} }
+  public static var {{aliasName}}: {{aliasType}} { {% call referenceName alias %} }
   {% endfor %}
 {% endmacro %}
 
@@ -14,8 +15,18 @@
     stops: [
       {% for stop in gradient.stops %}
       Gradient.Stop(
-        color: {%+ call swiftUIColor stop.color %},
-        location: {{ stop.position }}
+        {% if stop.color.value %}
+        color: {%+ call swiftUIColor stop.color.value %},
+        {% endif %}
+        {% if stop.color.alias %}
+        color: {%+ call referenceName stop.color.alias %},
+        {% endif %}
+        {% if stop.position.value %}
+        location: {{ stop.position.value }}
+        {% endif %}
+        {% if stop.position.alias %}
+        location: {%+ call referenceName stop.color.alias %}
+        {% endif %}
       ),
       {% endfor %}
     ]

--- a/Sources/DesignTokensGenerator/Resources/common.stencil
+++ b/Sources/DesignTokensGenerator/Resources/common.stencil
@@ -25,7 +25,7 @@
         location: {{ stop.position.value }}
         {% endif %}
         {% if stop.position.alias %}
-        location: {%+ call referenceName stop.color.alias %}
+        location: {%+ call referenceName stop.position.alias +%}
         {% endif %}
       ),
       {% endfor %}

--- a/Sources/DesignTokensGenerator/Resources/common.stencil
+++ b/Sources/DesignTokensGenerator/Resources/common.stencil
@@ -5,3 +5,19 @@
   static var {{aliasName}}: {{aliasType}} { {{referenceName}} }
   {% endfor %}
 {% endmacro %}
+
+{% macro swiftUIColor color %}Color(red: {{ color.red }}, green: {{ color.green }}, blue: {{ color.blue }}, opacity: {{ color.alpha }}){% endmacro %}
+
+{% macro uiKitColor color %}UIColor(red: {{ color.red }}, green: {{ color.green }}, blue: {{ color.blue }}, alpha: {{ color.alpha }}){% endmacro %}
+
+{% macro swiftUIGradient gradient %}Gradient(
+    stops: [
+      {% for stop in gradient.stops %}
+      Gradient.Stop(
+        color: {%+ call swiftUIColor stop.color %},
+        location: {{ stop.position }}
+      ),
+      {% endfor %}
+    ]
+  )
+{% endmacro %}

--- a/Sources/DesignTokensGenerator/Resources/gradient+swiftui.stencil
+++ b/Sources/DesignTokensGenerator/Resources/gradient+swiftui.stencil
@@ -4,14 +4,14 @@
 import SwiftUI
 
 {% import "common.stencil" %}
-{% set tokenType %}Color{% endset %}
+{% set tokenType %}Gradient{% endset %}
 {% macro tokensBlock tokens %}
   {% for token in tokens %}
   {% if token.description %}
   /// {{ token.description }}
   {% endif %}
   {% set tokenName %}{{ token.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords }}{% endset %}
-  static let {{ tokenName }} = {%+  call swiftUIColor token.color +%}
+  static let {{ tokenName }} = {%+  call swiftUIGradient token.gradient +%}
   {% endfor %}
 {% endmacro %}
 

--- a/Sources/DesignTokensGenerator/Resources/gradient+swiftui.stencil
+++ b/Sources/DesignTokensGenerator/Resources/gradient+swiftui.stencil
@@ -11,7 +11,7 @@ import SwiftUI
   /// {{ token.description }}
   {% endif %}
   {% set tokenName %}{{ token.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords }}{% endset %}
-  static let {{ tokenName }} = {%+  call swiftUIGradient token.gradient +%}
+  public static let {{ tokenName }} = {%+  call swiftUIGradient token.gradient +%}
   {% endfor %}
 {% endmacro %}
 

--- a/Sources/DesignTokensGenerator/Resources/number+foundation.stencil
+++ b/Sources/DesignTokensGenerator/Resources/number+foundation.stencil
@@ -1,0 +1,28 @@
+// Generated with swift-design-tokens – https://github.com/gaetanomatonti/swift-design-tokens
+
+#if canImport(Foundation)
+import Foundation
+
+{% import "common.stencil" %}
+{% set tokenType %}CGFloat{% endset %}
+{% macro tokensBlock tokens %}
+  {% for token in tokens %}
+  {% if token.description %}
+  /// {{ token.description }}
+  {% endif %}
+  {% set tokenName %}{{ token.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords }}{% endset %}
+  public static let {{ tokenName }}: {{tokenType}} = {{ token.number }}
+  {% endfor %}
+{% endmacro %}
+
+extension {{tokenType}} {
+
+  // MARK: - Tokens
+
+{% call tokensBlock tokens %}
+
+  // MARK: - Aliases
+
+{% call aliasesBlock aliases tokenType %}
+}
+#endif

--- a/Tests/DesignTokensCoreTests/DesignTokensTests.swift
+++ b/Tests/DesignTokensCoreTests/DesignTokensTests.swift
@@ -62,6 +62,26 @@ struct DesignTokenDecoding {
     )
   }
 
+  @Test func decodeGradientTokens() throws {
+    let data = try #require(loadJSON(named: "gradient"))
+    let tree = try decoder.decode(DesignTokenTree.self, from: data)
+
+    let expected = [
+      GradientToken(
+        name: "blue-to-red",
+        gradient: Gradient(
+          stops: [
+            Gradient.Stop(color: try Color("#0000ff"), position: 0),
+            Gradient.Stop(color: try Color("#ff0000"), position: 1),
+          ]
+        ),
+        path: ["blue-to-red"]
+      )
+    ]
+
+    #expect(tree.gradientTokens() == expected)
+  }
+
   fileprivate func loadJSON(named fileName: String) -> Data? {
     guard let url = Bundle.module.url(forResource: fileName, withExtension: "json") else {
       return nil

--- a/Tests/DesignTokensCoreTests/Resources/gradient.json
+++ b/Tests/DesignTokensCoreTests/Resources/gradient.json
@@ -1,0 +1,15 @@
+{
+  "blue-to-red": {
+    "$type": "gradient",
+    "$value": [
+      {
+        "color": "#0000ff",
+        "position": 0
+      },
+      {
+        "color": "#ff0000",
+        "position": 1
+      }
+    ]
+  }
+}

--- a/Tests/DesignTokensCoreTests/Tags.swift
+++ b/Tests/DesignTokensCoreTests/Tags.swift
@@ -2,5 +2,6 @@ import Testing
 
 extension Tag {
   @Tag static var critical: Self
+  @Tag static var toImprove: Self
 }
 

--- a/Tests/DesignTokensCoreTests/TreeReducerTests.swift
+++ b/Tests/DesignTokensCoreTests/TreeReducerTests.swift
@@ -21,10 +21,12 @@ struct TreeReducerTests {
     tree.root.add(foundation)
     tree.root.add(background)
     tree.root.add(Node(name: "small", value: .alias(["foundation", "small"]), path: ["small"]))
+    tree.root.add(Node(name: "blue-to-red", value: .gradient(.blueToRed), path: ["blue-to-red"]))
 
     let reducer = TreeReducer(trees: [tree])
     let (colorTokens, colorAliases) = reducer.colors()
     let (dimensionTokens, dimensionAliases) = reducer.dimensions()
+    let gradientTokens = reducer.gradients()
 
     #expect(
       colorTokens == [
@@ -47,6 +49,12 @@ struct TreeReducerTests {
     #expect(
       dimensionAliases == [
         AliasToken(name: "small", path: ["small"], reference: ["foundation", "small"])
+      ]
+    )
+
+    #expect(
+      gradientTokens == [
+        GradientToken(name: "blue-to-red", gradient: .blueToRed, path: ["blue-to-red"])
       ]
     )
   }
@@ -69,10 +77,12 @@ struct TreeReducerTests {
     var tree = DesignTokenTree()
     tree.root.add(background)
     tree.root.add(Node(name: "small", value: .alias(["foundation", "small"]), path: ["small"]))
+    tree.root.add(Node(name: "blue-to-red", value: .gradient(.blueToRed), path: ["blue-to-red"]))
 
     let reducer = TreeReducer(trees: [foundationTree, tree])
     let (colorTokens, colorAliases) = reducer.colors()
     let (dimensionTokens, dimensionAliases) = reducer.dimensions()
+    let gradientTokens = reducer.gradients()
 
     #expect(
       colorTokens == [
@@ -95,6 +105,12 @@ struct TreeReducerTests {
     #expect(
       dimensionAliases == [
         AliasToken(name: "small", path: ["small"], reference: ["foundation", "small"])
+      ]
+    )
+
+    #expect(
+      gradientTokens == [
+        GradientToken(name: "blue-to-red", gradient: .blueToRed, path: ["blue-to-red"])
       ]
     )
   }

--- a/Tests/DesignTokensCoreTests/TreeReducerTests.swift
+++ b/Tests/DesignTokensCoreTests/TreeReducerTests.swift
@@ -7,12 +7,13 @@ struct TreeReducerTests {
   @Test(
     "Reduce single tree",
     .bug("https://github.com/gaetanomatonti/swift-design-tokens/issues/22"),
-    .tags(.critical)
+    .tags(.critical, .toImprove)
   )
   func reduceSingleTree() {
     var tree = DesignTokenTree()
     var foundation = Node(name: "foundation", path: ["foundation"])
     foundation.add(Node(name: "white", type: .color, value: .color(.white), path: ["foundation", "white"]))
+    foundation.add(Node(name: "red", type: .color, value: .color(.red), path: ["foundation", "red"]))
     foundation.add(Node(name: "small", type: .dimension, value: .dimension(Dimension(8)), path: ["foundation", "small"]))
 
     var background = Node(name: "background", path: ["background"])
@@ -21,52 +22,86 @@ struct TreeReducerTests {
     tree.root.add(foundation)
     tree.root.add(background)
     tree.root.add(Node(name: "small", value: .alias(["foundation", "small"]), path: ["small"]))
-    tree.root.add(Node(name: "blue-to-red", value: .gradient(.blueToRed), path: ["blue-to-red"]))
+    tree.root.add(Node(name: "gradient-start", value: .number(0), path: ["gradient-start"]))
+    tree.root.add(
+      Node(
+        name: "blue-to-red",
+        value: .gradient(
+          Gradient(
+            stops: [
+              Gradient.Stop(color: .color(.blue), position: .alias(["gradient-start"])),
+              Gradient.Stop(color: .alias(["foundation", "red"]), position: .float(1)),
+            ]
+          )
+        ),
+        path: ["blue-to-red"]
+      )
+    )
 
     let reducer = TreeReducer(trees: [tree])
     let (colorTokens, colorAliases) = reducer.colors()
     let (dimensionTokens, dimensionAliases) = reducer.dimensions()
+    let (numberTokens, numberAliases) = reducer.numbers()
     let gradientTokens = reducer.gradients()
 
     #expect(
       colorTokens == [
-        ColorToken(name: "white", color: .white, path: ["foundation", "white"])
+        ColorToken(name: "white", color: .white, path: ["foundation", "white"]),
+        ColorToken(name: "red", color: .red, path: ["foundation", "red"]),
       ]
     )
 
     #expect(
       colorAliases == [
-        AliasToken(name: "base", path: ["background", "base"], reference: ["foundation", "white"])
+        AliasToken(name: "base", path: ["background", "base"], reference: ["foundation", "white"]),
       ]
     )
 
     #expect(
       dimensionTokens == [
-        DimensionToken(name: "small", dimension: Dimension(8), path: ["foundation", "small"])
+        DimensionToken(name: "small", dimension: Dimension(8), path: ["foundation", "small"]),
       ]
     )
 
     #expect(
       dimensionAliases == [
-        AliasToken(name: "small", path: ["small"], reference: ["foundation", "small"])
+        AliasToken(name: "small", path: ["small"], reference: ["foundation", "small"]),
       ]
     )
 
     #expect(
+      numberTokens == [
+        NumberToken(name: "gradient-start", number: 0, path: ["gradient-start"]),
+      ]
+    )
+
+    #expect(numberAliases.isEmpty)
+
+    #expect(
       gradientTokens == [
-        GradientToken(name: "blue-to-red", gradient: .blueToRed, path: ["blue-to-red"])
+        GradientToken(
+          name: "blue-to-red",
+          gradient: Gradient(
+            stops: [
+              Gradient.Stop(color: .color(.blue), position: .alias(["gradient-start"])),
+              Gradient.Stop(color: .alias(["foundation", "red"]), position: .float(1)),
+            ]
+          ),
+          path: ["blue-to-red"]
+        ),
       ]
     )
   }
 
   @Test(
     "Reduce multiple trees with aliases and values in different trees",
-    .tags(.critical)
+    .tags(.critical, .toImprove)
   )
   func reduceMultipleTrees() {
     var foundationTree = DesignTokenTree()
     var foundation = Node(name: "foundation", path: ["foundation"])
     foundation.add(Node(name: "white", type: .color, value: .color(.white), path: ["foundation", "white"]))
+    foundation.add(Node(name: "red", type: .color, value: .color(.red), path: ["foundation", "red"]))
     foundation.add(Node(name: "small", type: .dimension, value: .dimension(Dimension(8)), path: ["foundation", "small"]))
 
     var background = Node(name: "background", path: ["background"])
@@ -77,40 +112,73 @@ struct TreeReducerTests {
     var tree = DesignTokenTree()
     tree.root.add(background)
     tree.root.add(Node(name: "small", value: .alias(["foundation", "small"]), path: ["small"]))
-    tree.root.add(Node(name: "blue-to-red", value: .gradient(.blueToRed), path: ["blue-to-red"]))
+    tree.root.add(Node(name: "gradient-start", value: .number(0), path: ["gradient-start"]))
+    tree.root.add(
+      Node(
+        name: "blue-to-red",
+        value: .gradient(
+          Gradient(
+            stops: [
+              Gradient.Stop(color: .color(.blue), position: .alias(["gradient-start"])),
+              Gradient.Stop(color: .alias(["foundation", "red"]), position: .float(1)),
+            ]
+          )
+        ),
+        path: ["blue-to-red"]
+      )
+    )
 
     let reducer = TreeReducer(trees: [foundationTree, tree])
     let (colorTokens, colorAliases) = reducer.colors()
     let (dimensionTokens, dimensionAliases) = reducer.dimensions()
+    let (numberTokens, numberAliases) = reducer.numbers()
     let gradientTokens = reducer.gradients()
 
     #expect(
       colorTokens == [
-        ColorToken(name: "white", color: .white, path: ["foundation", "white"])
+        ColorToken(name: "white", color: .white, path: ["foundation", "white"]),
+        ColorToken(name: "red", color: .red, path: ["foundation", "red"]),
       ]
     )
 
     #expect(
       colorAliases == [
-        AliasToken(name: "base", path: ["background", "base"], reference: ["foundation", "white"])
+        AliasToken(name: "base", path: ["background", "base"], reference: ["foundation", "white"]),
       ]
     )
 
     #expect(
       dimensionTokens == [
-        DimensionToken(name: "small", dimension: Dimension(8), path: ["foundation", "small"])
+        DimensionToken(name: "small", dimension: Dimension(8), path: ["foundation", "small"]),
       ]
     )
 
     #expect(
       dimensionAliases == [
-        AliasToken(name: "small", path: ["small"], reference: ["foundation", "small"])
+        AliasToken(name: "small", path: ["small"], reference: ["foundation", "small"]),
       ]
     )
 
     #expect(
+      numberTokens == [
+        NumberToken(name: "gradient-start", number: 0, path: ["gradient-start"]),
+      ]
+    )
+
+    #expect(numberAliases.isEmpty)
+
+    #expect(
       gradientTokens == [
-        GradientToken(name: "blue-to-red", gradient: .blueToRed, path: ["blue-to-red"])
+        GradientToken(
+          name: "blue-to-red",
+          gradient: Gradient(
+            stops: [
+              Gradient.Stop(color: .color(.blue), position: .alias(["gradient-start"])),
+              Gradient.Stop(color: .alias(["foundation", "red"]), position: .float(1)),
+            ]
+          ),
+          path: ["blue-to-red"]
+        ),
       ]
     )
   }

--- a/Tests/DesignTokensCoreTests/TreeReducerTests.swift
+++ b/Tests/DesignTokensCoreTests/TreeReducerTests.swift
@@ -29,8 +29,8 @@ struct TreeReducerTests {
         value: .gradient(
           Gradient(
             stops: [
-              Gradient.Stop(color: .color(.blue), position: .alias(["gradient-start"])),
-              Gradient.Stop(color: .alias(["foundation", "red"]), position: .float(1)),
+              Gradient.Stop(color: .value(.blue), position: .alias(["gradient-start"])),
+              Gradient.Stop(color: .alias(["foundation", "red"]), position: .value(1)),
             ]
           )
         ),
@@ -83,8 +83,8 @@ struct TreeReducerTests {
           name: "blue-to-red",
           gradient: Gradient(
             stops: [
-              Gradient.Stop(color: .color(.blue), position: .alias(["gradient-start"])),
-              Gradient.Stop(color: .alias(["foundation", "red"]), position: .float(1)),
+              Gradient.Stop(color: .value(.blue), position: .alias(["gradient-start"])),
+              Gradient.Stop(color: .alias(["foundation", "red"]), position: .value(1)),
             ]
           ),
           path: ["blue-to-red"]
@@ -119,8 +119,8 @@ struct TreeReducerTests {
         value: .gradient(
           Gradient(
             stops: [
-              Gradient.Stop(color: .color(.blue), position: .alias(["gradient-start"])),
-              Gradient.Stop(color: .alias(["foundation", "red"]), position: .float(1)),
+              Gradient.Stop(color: .value(.blue), position: .alias(["gradient-start"])),
+              Gradient.Stop(color: .alias(["foundation", "red"]), position: .value(1)),
             ]
           )
         ),
@@ -173,8 +173,8 @@ struct TreeReducerTests {
           name: "blue-to-red",
           gradient: Gradient(
             stops: [
-              Gradient.Stop(color: .color(.blue), position: .alias(["gradient-start"])),
-              Gradient.Stop(color: .alias(["foundation", "red"]), position: .float(1)),
+              Gradient.Stop(color: .value(.blue), position: .alias(["gradient-start"])),
+              Gradient.Stop(color: .alias(["foundation", "red"]), position: .value(1)),
             ]
           ),
           path: ["blue-to-red"]

--- a/Tests/DesignTokensCoreTests/TypeTests/AliasDecodingTests.swift
+++ b/Tests/DesignTokensCoreTests/TypeTests/AliasDecodingTests.swift
@@ -27,6 +27,6 @@ struct AliasDecoding {
   )
   func successfulAliasDecoding(reference: SUT<String, [String]>) throws {
     let alias = try Alias(reference.argument)
-    #expect(alias.path == reference.expected)
+    #expect(alias.reference == reference.expected)
   }
 }

--- a/Tests/GeneratorTests/ConfigurationTests.swift
+++ b/Tests/GeneratorTests/ConfigurationTests.swift
@@ -18,11 +18,16 @@ struct ConfigurationTests {
         inputPath: "design-tokens-dimensions.json",
         outputPath: "Output/Dimensions/"
       )
+      .gradient(
+        inputPath: "design-tokens-gradients.json",
+        outputPath: "Output/Gradients/"
+      )
 
     #expect(configuration.inputPaths == ["design-tokens.json"])
     #expect(configuration.outputPath == "Output/")
     #expect(configuration.colorConfiguration == ColorConfiguration(inputPath: "design-tokens-colors.json", outputPath: "Output/Colors/", formats: [.swiftUI, .uiKit]))
     #expect(configuration.dimensionConfiguration == DimensionConfiguration(inputPath: "design-tokens-dimensions.json", outputPath: "Output/Dimensions/"))
+    #expect(configuration.gradientConfiguration == GradientConfiguration(inputPath: "design-tokens-gradients.json", outputPath: "Output/Gradients/"))
   }
   
   @Test
@@ -40,6 +45,10 @@ struct ConfigurationTests {
       .dimension(
         inputPath: "design-tokens-dimensions.json",
         outputPath: "Output/Dimensions/"
+      )
+      .gradient(
+        inputPath: "design-tokens-gradients.json",
+        outputPath: "Output/Gradients/"
       )
 
     let data = try #require(loadJSON(named: "configuration"))
@@ -67,12 +76,16 @@ struct ConfigurationTests {
         inputPath: "design-tokens-dimensions.json",
         outputPath: "Output/Dimensions/"
       )
+      .gradient(
+        inputPath: "design-tokens-gradients.json",
+        outputPath: "Output/Gradients/"
+      )
 
+    #expect(throws: Never.self) {
     let data = try encoder.encode(configuration)
 
     let decoder = JSONDecoder()
-    
-    #expect(throws: Never.self) {
+
       let result = try decoder.decode(Configuration.self, from: data)
       #expect(result == configuration)
     }

--- a/Tests/GeneratorTests/ConfigurationValidatorTests.swift
+++ b/Tests/GeneratorTests/ConfigurationValidatorTests.swift
@@ -17,12 +17,16 @@ struct ConfigurationValidatorTests {
         .input("design-tokens.json")
         .output("Output/")
         .color(formats: .swiftUI)
-        .dimension(),
+        .dimension()
+        .gradient()
+        .number(),
       Configuration()
         .input("design-tokens.json")
         .output("Output/")
         .color(inputPath: "design-tokens.json", outputPath: "Output", formats: .swiftUI)
-        .dimension(inputPath: "design-tokens.json", outputPath: "Output"),
+        .dimension(inputPath: "design-tokens.json", outputPath: "Output")
+        .gradient(inputPath: "design-tokens.json", outputPath: "Output")
+        .number(inputPath: "design-tokens.json", outputPath: "Output"),
     ]
   )
   func configurationIsValid(_ configuration: Configuration) throws {
@@ -58,6 +62,20 @@ struct ConfigurationValidatorTests {
   )
   func configurationHasNoOutput(_ configuration: Configuration) throws {
     #expect(throws: ConfigurationValidationFailure.noOutputProvided) {
+      let validator = ConfigurationValidator(configuration: configuration)
+      try validator.validate()
+    }
+  }
+
+  @Test(
+    arguments: [
+      Configuration
+        .scaffold(inputPaths: ["design-tokens.json"], outputPath: "Output/")
+        .gradient(),
+    ]
+  )
+  func configurationHasNoNumberConfiguration(_ configuration: Configuration) throws {
+    #expect(throws: ConfigurationValidationFailure.gradientConfigurationRequiresNumberConfiguration) {
       let validator = ConfigurationValidator(configuration: configuration)
       try validator.validate()
     }

--- a/Tests/GeneratorTests/Resources/configuration.json
+++ b/Tests/GeneratorTests/Resources/configuration.json
@@ -12,5 +12,9 @@
   "dimensions": {
     "input": "design-tokens-dimensions.json",
     "output" : "Output/Dimensions/"
+  },
+  "gradients": {
+    "input": "design-tokens-gradients.json",
+    "output" : "Output/Gradients/"
   }
 }


### PR DESCRIPTION
Added support for the `gradient` token type.

These changes allow for source code generation of gradient tokens. Additionally, the refactor on the `TokenValue` decoding logic facilitates the introduction of other composite types.

### Tasks
- [x] Refactor `TokenValue` decoding logic.
- [x] Add gradient composite value decoding. Closes #19
- [x] Add gradient configuration in `Configuration`.
- [x] Add gradient tokens source code generation.
- [x] Add color, and position aliases support.
- [x] Add number token type support. Closes #26
- [x] Update Output documentation.

### Blocked by
- #22