### PR TITLE
Fix Alias Resolving

### DIFF
--- a/Sources/DesignTokensCore/DesignTokenTree.swift
+++ b/Sources/DesignTokensCore/DesignTokenTree.swift
@@ -8,74 +8,16 @@ package struct DesignTokenTree {
   /// The root node of the tree.
   ///
   /// This node is not an actual token or group, so it should be ignored when traversing the tree.
-  let root: Node
+  var root: Node
 
-  // MARK: - Functions
-
-  /// Retrieves all color tokens, and aliases in the tree.
-  /// - Returns: A tuple of `[ColorToken]`, and `[AliasToken]` that reference color tokens.
-  package func colorTokens() -> (tokens: [ColorToken], aliases: [AliasToken]) {
-    var tokens: [ColorToken] = []
-    var aliases: [AliasToken] = []
-
-    root.depthFirstTraversal { node in
-      switch node.value {
-      case let .color(color):
-        let token =  ColorToken(name: node.name, description: node.description, color: color, path: node.path)
-        tokens.append(token)
-
-      case let .alias(path):
-        let alias = AliasToken(name: node.name, description: node.description, path: node.path, reference: path)
-        aliases.append(alias)
-
-      default:
-        break
-      }
-    }
-
-    tokens.sort()
-
-    aliases.removeAll { alias in
-      !tokens.contains { $0.path == alias.reference }
-    }
-    aliases.sort()
-
-    return (tokens, aliases)
-  }
-
-  /// Retrieves all dimension tokens in the tree.
-  /// - Returns: A tuple of `[DimensionToken]`, and `[AliasToken]` that reference dimension tokens.
-  package func dimensionTokens() -> (tokens: [DimensionToken], aliases: [AliasToken]) {
-    var tokens: [DimensionToken] = []
-    var aliases: [AliasToken] = []
-
-    root.depthFirstTraversal { node in
-      switch node.value {
-      case let .dimension(dimension):
-        let token = DimensionToken(name: node.name, description: node.description, dimension: dimension, path: node.path)
-        tokens.append(token)
-
-      case let .alias(path):
-        let alias = AliasToken(name: node.name, description: node.description, path: node.path, reference: path)
-        aliases.append(alias)
-
-      default:
-        break
-      }
-    }
-
-    tokens.sort()
-    aliases.removeAll { alias in
-      !tokens.contains { $0.path == alias.reference }
-    }
-
-    return (tokens, aliases)
+  init() {
+    self.root = Node(name: "Design Tokens")
   }
 }
 
 extension DesignTokenTree: Decodable {
   package init(from decoder: any Decoder) throws {
-    var root = Node(name: "Design Tokens")
+    self.init()
 
     let container = try decoder.container(keyedBy: AnyCodingKey.self)
 
@@ -83,7 +25,5 @@ extension DesignTokenTree: Decodable {
       let node = try container.decode(Node.self, forKey: key, configuration: TokenDecodingConfiguration())
       root.add(node)
     }
-
-    self.root = root
   }
 }

--- a/Sources/DesignTokensCore/DesignTokenTree.swift
+++ b/Sources/DesignTokensCore/DesignTokenTree.swift
@@ -34,6 +34,10 @@ package struct DesignTokenTree {
     }
 
     tokens.sort()
+
+    aliases.removeAll { alias in
+      !tokens.contains { $0.path == alias.reference }
+    }
     aliases.sort()
 
     return (tokens, aliases)
@@ -61,7 +65,9 @@ package struct DesignTokenTree {
     }
 
     tokens.sort()
-    aliases.sort()
+    aliases.removeAll { alias in
+      !tokens.contains { $0.path == alias.reference }
+    }
 
     return (tokens, aliases)
   }

--- a/Sources/DesignTokensCore/TreeReducer.swift
+++ b/Sources/DesignTokensCore/TreeReducer.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// An object that reduces multiple trees into the different types of tokens.
+package struct TreeReducer {
+
+  // MARK: - Stored Properties
+
+  private let trees: [DesignTokenTree]
+
+  // MARK: - Init
+
+  package init(trees: [DesignTokenTree]) {
+    self.trees = trees
+  }
+
+  // MARK: - Functions
+
+  /// Reduces the trees into all color tokens, and matching aliases.
+  /// - Returns: A tuple of `[ColorToken]`, and `[AliasToken]` that reference color tokens.
+  package func colors() -> ([ColorToken], [AliasToken]) {
+    let tokens = colorTokens()
+
+    let aliases = aliasTokens { alias in
+      tokens.contains { token in
+        token.path == alias.reference
+      }
+    }
+
+    return (tokens, aliases)
+  }
+
+  /// Reduces the trees into all dimension tokens, and matching aliases.
+  /// - Returns: A tuple of `[DimensionToken]`, and `[AliasToken]` that reference color tokens.
+  package func dimensions() -> ([DimensionToken], [AliasToken]) {
+    let tokens = dimensionTokens()
+
+    let aliases = aliasTokens { alias in
+      tokens.contains { token in
+        token.path == alias.reference
+      }
+    }
+
+    return (tokens, aliases)
+  }
+
+  func colorTokens() -> [ColorToken] {
+    trees.reduce(into: []) { result, tree in
+      tree.root.depthFirstTraversal { node in
+        if case let .color(color) = node.value {
+          let token = ColorToken(name: node.name, description: node.description, color: color, path: node.path)
+          result.append(token)
+        }
+      }
+    }
+  }
+
+  func dimensionTokens() -> [DimensionToken] {
+    trees.reduce(into: []) { result, tree in
+      tree.root.depthFirstTraversal { node in
+        if case let .dimension(dimension) = node.value {
+          let token = DimensionToken(name: node.name, description: node.description, dimension: dimension, path: node.path)
+          result.append(token)
+        }
+      }
+    }
+  }
+
+  func aliasTokens(where predicate: (AliasToken) -> Bool) -> [AliasToken] {
+    trees.reduce(into: []) { result, tree in
+      tree.root.depthFirstTraversal { node in
+        if case let .alias(path) = node.value {
+          let token = AliasToken(name: node.name, description: node.description, path: node.path, reference: path)
+
+          if predicate(token) {
+            result.append(token)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/DesignTokensCore/Type/Color.swift
+++ b/Sources/DesignTokensCore/Type/Color.swift
@@ -66,3 +66,7 @@ package struct Color {
 }
 
 extension Color: Equatable {}
+
+extension Color {
+  static let white = Color(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+}

--- a/Sources/DesignTokensGenerator/Generators/OutputGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/OutputGenerator.swift
@@ -92,12 +92,9 @@ package struct OutputGenerator {
     }
     
     let outputURL = outputURL(with: configurationLocator, for: outputPath)
-    
-    let (tokens, aliases): ([ColorToken], [AliasToken]) = trees.reduce(into: (resultingTokens: [], resultingAliases: [])) { result, tree in
-      let (tokens, aliases) = tree.colorTokens()
-      result.resultingTokens.append(contentsOf: tokens)
-      result.resultingAliases.append(contentsOf: aliases)
-    }
+
+    let reducer = TreeReducer(trees: trees)
+    let (tokens, aliases) = reducer.colors()
     
     try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
 
@@ -127,11 +124,8 @@ package struct OutputGenerator {
     
     let outputURL = outputURL(with: configurationLocator, for: outputPath)
 
-    let (tokens, aliases): ([DimensionToken], [AliasToken]) = trees.reduce(into: (resultingTokens: [], resultingAliases: [])) { result, tree in
-      let (tokens, aliases) = tree.dimensionTokens()
-      result.resultingTokens.append(contentsOf: tokens)
-      result.resultingAliases.append(contentsOf: aliases)
-    }
+    let reducer = TreeReducer(trees: trees)
+    let (tokens, aliases) = reducer.dimensions()
 
     let sourceCodeGenerator = DimensionSourceCodeGenerator(tokens: tokens, aliases: aliases)
     let files = try sourceCodeGenerator.generate(with: StencilEnvironmentProvider.swift())

--- a/Tests/DesignTokensCoreTests/DesignTokensTests.swift
+++ b/Tests/DesignTokensCoreTests/DesignTokensTests.swift
@@ -42,11 +42,18 @@ struct DesignTokenDecoding {
     let data = try #require(loadJSON(named: "groups"))
     let tree = try decoder.decode(DesignTokenTree.self, from: data)
 
+    let (tokens, aliases) = tree.colorTokens()
+
     #expect(
-      tree.colorTokens().tokens == [
+      tokens == [
         ColorToken(name: "red", color: Color(red: 1, green: 0, blue: 0, alpha: 1), path: ["colors", "red"]),
-        ColorToken(name: "base", color: Color(red: 1, green: 1, blue: 1, alpha: 1), path: ["colors", "background", "base"]),
         ColorToken(name: "primary", color: Color(red: 0, green: 0, blue: 0, alpha: 1), path: ["colors", "text", "primary"]),
+      ]
+    )
+
+    #expect(
+      aliases == [
+        AliasToken(name: "base", path: ["colors", "background", "base"], reference: ["colors", "red"]),
       ]
     )
   }
@@ -55,11 +62,15 @@ struct DesignTokenDecoding {
     let data = try #require(loadJSON(named: "groups"))
     let tree = try decoder.decode(DesignTokenTree.self, from: data)
 
+    let (tokens, aliases) = tree.dimensionTokens()
+
     #expect(
-      tree.dimensionTokens().tokens == [
+      tokens == [
         DimensionToken(name: "small", dimension: Dimension(8), path: ["small"])
       ]
     )
+
+    #expect(aliases.isEmpty)
   }
 
   fileprivate func loadJSON(named fileName: String) -> Data? {

--- a/Tests/DesignTokensCoreTests/DesignTokensTests.swift
+++ b/Tests/DesignTokensCoreTests/DesignTokensTests.swift
@@ -38,41 +38,6 @@ struct DesignTokenDecoding {
     #expect(colors.children.count == 3)
   }
 
-  @Test func fetchColorTokens() throws {
-    let data = try #require(loadJSON(named: "groups"))
-    let tree = try decoder.decode(DesignTokenTree.self, from: data)
-
-    let (tokens, aliases) = tree.colorTokens()
-
-    #expect(
-      tokens == [
-        ColorToken(name: "red", color: Color(red: 1, green: 0, blue: 0, alpha: 1), path: ["colors", "red"]),
-        ColorToken(name: "primary", color: Color(red: 0, green: 0, blue: 0, alpha: 1), path: ["colors", "text", "primary"]),
-      ]
-    )
-
-    #expect(
-      aliases == [
-        AliasToken(name: "base", path: ["colors", "background", "base"], reference: ["colors", "red"]),
-      ]
-    )
-  }
-
-  @Test func fetchDimensionTokens() throws {
-    let data = try #require(loadJSON(named: "groups"))
-    let tree = try decoder.decode(DesignTokenTree.self, from: data)
-
-    let (tokens, aliases) = tree.dimensionTokens()
-
-    #expect(
-      tokens == [
-        DimensionToken(name: "small", dimension: Dimension(8), path: ["small"])
-      ]
-    )
-
-    #expect(aliases.isEmpty)
-  }
-
   fileprivate func loadJSON(named fileName: String) -> Data? {
     guard let url = Bundle.module.url(forResource: fileName, withExtension: "json") else {
       return nil

--- a/Tests/DesignTokensCoreTests/Resources/groups.json
+++ b/Tests/DesignTokensCoreTests/Resources/groups.json
@@ -18,7 +18,7 @@
     "background": {
       "$description": "Background colors",
       "base": {
-        "$value": "#FFFFFF",
+        "$value": "{colors.red}",
         "$type": "color"
       }
     }

--- a/Tests/DesignTokensCoreTests/Tags.swift
+++ b/Tests/DesignTokensCoreTests/Tags.swift
@@ -1,0 +1,6 @@
+import Testing
+
+extension Tag {
+  @Tag static var critical: Self
+}
+

--- a/Tests/DesignTokensCoreTests/TreeReducerTests.swift
+++ b/Tests/DesignTokensCoreTests/TreeReducerTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import DesignTokensCore
+
+@Suite
+struct TreeReducerTests {
+  @Test(
+    "Reduce single tree",
+    .bug("https://github.com/gaetanomatonti/swift-design-tokens/issues/22"),
+    .tags(.critical)
+  )
+  func reduceSingleTree() {
+    var tree = DesignTokenTree()
+    var foundation = Node(name: "foundation", path: ["foundation"])
+    foundation.add(Node(name: "white", type: .color, value: .color(.white), path: ["foundation", "white"]))
+    foundation.add(Node(name: "small", type: .dimension, value: .dimension(Dimension(8)), path: ["foundation", "small"]))
+
+    var background = Node(name: "background", path: ["background"])
+    background.add(Node(name: "base", value: .alias(["foundation", "white"]), path: ["background", "base"]))
+
+    tree.root.add(foundation)
+    tree.root.add(background)
+    tree.root.add(Node(name: "small", value: .alias(["foundation", "small"]), path: ["small"]))
+
+    let reducer = TreeReducer(trees: [tree])
+    let (colorTokens, colorAliases) = reducer.colors()
+    let (dimensionTokens, dimensionAliases) = reducer.dimensions()
+
+    #expect(
+      colorTokens == [
+        ColorToken(name: "white", color: .white, path: ["foundation", "white"])
+      ]
+    )
+
+    #expect(
+      colorAliases == [
+        AliasToken(name: "base", path: ["background", "base"], reference: ["foundation", "white"])
+      ]
+    )
+
+    #expect(
+      dimensionTokens == [
+        DimensionToken(name: "small", dimension: Dimension(8), path: ["foundation", "small"])
+      ]
+    )
+
+    #expect(
+      dimensionAliases == [
+        AliasToken(name: "small", path: ["small"], reference: ["foundation", "small"])
+      ]
+    )
+  }
+
+  @Test(
+    "Reduce multiple trees with aliases and values in different trees",
+    .tags(.critical)
+  )
+  func reduceMultipleTrees() {
+    var foundationTree = DesignTokenTree()
+    var foundation = Node(name: "foundation", path: ["foundation"])
+    foundation.add(Node(name: "white", type: .color, value: .color(.white), path: ["foundation", "white"]))
+    foundation.add(Node(name: "small", type: .dimension, value: .dimension(Dimension(8)), path: ["foundation", "small"]))
+
+    var background = Node(name: "background", path: ["background"])
+    background.add(Node(name: "base", value: .alias(["foundation", "white"]), path: ["background", "base"]))
+
+    foundationTree.root.add(foundation)
+
+    var tree = DesignTokenTree()
+    tree.root.add(background)
+    tree.root.add(Node(name: "small", value: .alias(["foundation", "small"]), path: ["small"]))
+
+    let reducer = TreeReducer(trees: [foundationTree, tree])
+    let (colorTokens, colorAliases) = reducer.colors()
+    let (dimensionTokens, dimensionAliases) = reducer.dimensions()
+
+    #expect(
+      colorTokens == [
+        ColorToken(name: "white", color: .white, path: ["foundation", "white"])
+      ]
+    )
+
+    #expect(
+      colorAliases == [
+        AliasToken(name: "base", path: ["background", "base"], reference: ["foundation", "white"])
+      ]
+    )
+
+    #expect(
+      dimensionTokens == [
+        DimensionToken(name: "small", dimension: Dimension(8), path: ["foundation", "small"])
+      ]
+    )
+
+    #expect(
+      dimensionAliases == [
+        AliasToken(name: "small", path: ["small"], reference: ["foundation", "small"])
+      ]
+    )
+  }
+}


### PR DESCRIPTION
Fixes an issue where aliases were not resolved correctly.
- Aliases were included in source code regardless of the type they referenced.
- Aliases were not resolved if the referenced token was not in the same tree.

Fixes #22