### PR TITLE
Improve ConfigurationLocator and Generate Command

### DIFF
--- a/Sources/DesignTokensGenerator/Configuration/ConfigurationLoader.swift
+++ b/Sources/DesignTokensGenerator/Configuration/ConfigurationLoader.swift
@@ -19,7 +19,7 @@ struct ConfigurationLoader {
   /// Loads, and decodes the configuration manifest.
   /// - Returns: The decoded configuration manifest.
   func load() throws -> Configuration {
-    let data = try Data(contentsOf: configurationLocator.fileURL)
+    let data = try Data(contentsOf: configurationLocator.manifestURL)
     let decoder = JSONDecoder()
     return try decoder.decode(Configuration.self, from: data)
   }

--- a/Sources/DesignTokensGenerator/Configuration/ConfigurationLocator.swift
+++ b/Sources/DesignTokensGenerator/Configuration/ConfigurationLocator.swift
@@ -1,43 +1,44 @@
 import Foundation
 
 /// An object that locates the configuration file.
-struct ConfigurationLocator {
+package struct ConfigurationLocator {
 
   // MARK: - Stored Properties
 
-  /// The name of the configuration manifest file.
-  private let fileName: String?
-
   /// The `URL` to the configuration manifest.
-  private let configurationURL: URL
+  let manifestURL: URL
 
   // MARK: - Computed Properties
 
-  /// The `URL` to the configuration file.
-  var fileURL: URL {
-    if configurationURL.isDirectory {
-      configurationURL
-        .appending(path: fileName ?? defaultConfigurationFileName)
-        .appendingPathExtension("json")
-    } else {
-      configurationURL
-    }
-  }
-
   /// The `URL` to the directory containing the configuration file.
   var directoryURL: URL {
-    if configurationURL.isDirectory {
-      configurationURL
-    } else {
-      configurationURL
-        .deletingLastPathComponent()
-    }
+    manifestURL
+      .deletingLastPathComponent()
   }
 
   // MARK: - Init
 
-  init(fileName: String? = nil, configurationURL: URL) {
-    self.fileName = fileName
-    self.configurationURL = configurationURL
+  package init(configurationManifestURL: URL) throws {
+    guard configurationManifestURL.pathExtension == "json" else {
+      throw Failure.invalidManifestURL
+    }
+    
+    self.manifestURL = configurationManifestURL
+  }
+}
+
+extension ConfigurationLocator {
+  enum Failure: Error {
+    /// The `URL` is not a valid configuration manifest URL.
+    case invalidManifestURL
+  }
+}
+
+extension ConfigurationLocator.Failure: LocalizedError {
+  var errorDescription: String? {
+    switch self {
+    case .invalidManifestURL:
+      return "The URL is not a valid configuration manifest URL."
+    }
   }
 }

--- a/Sources/DesignTokensGenerator/Generators/ConfigurationGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/ConfigurationGenerator.swift
@@ -4,20 +4,24 @@ import Foundation
 package struct ConfigurationGenerator {
   
   // MARK: - Stored Properties
-  
-  /// The locator for the configuration manifest.
-  private let configurationLocator: ConfigurationLocator
+
+  /// The name of the file to generate.
+  private let fileName: String
+
+  /// The directory where the configuration manifest will be generated.
+  private let configurationOutputURL: URL
 
   /// The path to the input design tokens file.
   private let inputPaths: [String]
 
-  /// The path to the directory where the output will be generated.
+  /// The path to the directory where the tokens' output will be generated.
   private let outputPath: String
 
   // MARK: - Init
   
-  package init(fileName: String?, configurationURL: URL, inputPaths: [String], outputPath: String) {
-    self.configurationLocator = ConfigurationLocator(fileName: fileName, configurationURL: configurationURL)
+  package init(fileName: String, configurationOutputURL: URL, inputPaths: [String], outputPath: String) {
+    self.fileName = fileName
+    self.configurationOutputURL = configurationOutputURL
     self.inputPaths = inputPaths
     self.outputPath = outputPath
   }
@@ -35,6 +39,11 @@ package struct ConfigurationGenerator {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
 
     let data = try encoder.encode(configuration)
-    try data.write(to: configurationLocator.fileURL)
+
+    let outputURL = configurationOutputURL
+      .appending(path: fileName)
+      .appendingPathExtension("json")
+
+    try data.write(to: outputURL)
   }
 }

--- a/Sources/DesignTokensGenerator/Generators/OutputGenerator.swift
+++ b/Sources/DesignTokensGenerator/Generators/OutputGenerator.swift
@@ -12,8 +12,8 @@ package struct OutputGenerator {
 
   // MARK: - Stored Properties
   
-  package init(configurationURL: URL) {
-    self.configurationLocator = ConfigurationLocator(configurationURL: configurationURL)
+  package init(using configurationLocator: ConfigurationLocator) {
+    self.configurationLocator = configurationLocator
   }
   
   // MARK: - Functions

--- a/Sources/DesignTokensTool/Generate.swift
+++ b/Sources/DesignTokensTool/Generate.swift
@@ -18,10 +18,12 @@ struct Generate: ParsableCommand {
       URL(filePath: $0)
     }
   )
-  var configurationURL: URL = URL(filePath: FileManager.default.currentDirectoryPath)
+  var configurationManifestURL: URL = URL(filePath: FileManager.default.currentDirectoryPath)
 
   func run() throws {
-    let generator = OutputGenerator(configurationURL: configurationURL)
+    let configurationLocator = try ConfigurationLocator(configurationManifestURL: configurationManifestURL)
+
+    let generator = OutputGenerator(using: configurationLocator)
     try generator.generate()
   }
 }

--- a/Sources/DesignTokensTool/Generate.swift
+++ b/Sources/DesignTokensTool/Generate.swift
@@ -18,7 +18,7 @@ struct Generate: ParsableCommand {
       URL(filePath: $0)
     }
   )
-  var configurationManifestURL: URL = URL(filePath: FileManager.default.currentDirectoryPath)
+  var configurationManifestURL: URL
 
   func run() throws {
     let configurationLocator = try ConfigurationLocator(configurationManifestURL: configurationManifestURL)

--- a/Sources/DesignTokensTool/Init.swift
+++ b/Sources/DesignTokensTool/Init.swift
@@ -21,7 +21,7 @@ struct Init: ParsableCommand {
       URL(filePath: $0)
     }
   )
-  var configurationURL: URL = URL(filePath: FileManager.default.currentDirectoryPath)
+  var configurationOutputURL: URL = URL(filePath: FileManager.default.currentDirectoryPath)
 
   @Option(
     name: [
@@ -44,7 +44,7 @@ struct Init: ParsableCommand {
   func run() throws {
     let configurationGenerator = ConfigurationGenerator(
       fileName: name,
-      configurationURL: configurationURL,
+      configurationOutputURL: configurationOutputURL,
       inputPaths: inputPaths,
       outputPath: outputPath
     )

--- a/Tests/GeneratorTests/ConfigurationGeneratorTests.swift
+++ b/Tests/GeneratorTests/ConfigurationGeneratorTests.swift
@@ -10,7 +10,7 @@ struct ConfigurationGeneratorTests {
     
     let configurationGenerator = ConfigurationGenerator(
       fileName: "configuration",
-      configurationURL: directoryURL,
+      configurationOutputURL: directoryURL,
       inputPaths: ["design-tokens.json"],
       outputPath: "Output/"
     )
@@ -24,7 +24,7 @@ struct ConfigurationGeneratorTests {
     
     #expect(fileExists)
     
-    let configurationLocator = ConfigurationLocator(configurationURL: outputURL)
+    let configurationLocator = try ConfigurationLocator(configurationManifestURL: outputURL)
     let configurationLoader = ConfigurationLoader(using: configurationLocator)
     
     #expect(throws: Never.self) {

--- a/Tests/GeneratorTests/ConfigurationLocatorTests.swift
+++ b/Tests/GeneratorTests/ConfigurationLocatorTests.swift
@@ -5,28 +5,35 @@ import Testing
 @Suite
 struct ConfigurationLocatorTests {
   @Test
-  func configurationManifestLocationFromFile() throws {
+  func initializationWithFileURLIsSuccessful() throws {
     let directoryURL = FileManager.default.temporaryDirectory
     let locationURL = directoryURL
       .appending(path: "configuration")
       .appendingPathExtension("json")
-    
-    let locator = ConfigurationLocator(fileName: "configuration", configurationURL: locationURL)
-    
-    #expect(locator.fileURL == locationURL)
-    #expect(locator.directoryURL == directoryURL)
+
+    #expect(throws: Never.self) {
+      try ConfigurationLocator(configurationManifestURL: locationURL)
+    }
   }
   
   @Test
-  func configurationManifestLocationFromDirectory() throws {
+  func initializationWithDirectoryURLFails() throws {
+    let directoryURL = FileManager.default.temporaryDirectory
+
+    #expect(throws: ConfigurationLocator.Failure.invalidManifestURL) {
+      try ConfigurationLocator(configurationManifestURL: directoryURL)
+    }
+  }
+
+  @Test
+  func directoryURLIsComputedCorrectly() throws {
     let directoryURL = FileManager.default.temporaryDirectory
     let locationURL = directoryURL
       .appending(path: "configuration")
       .appendingPathExtension("json")
+
+    let locator = try ConfigurationLocator(configurationManifestURL: locationURL)
     
-    let locator = ConfigurationLocator(fileName: "configuration", configurationURL: directoryURL)
-    
-    #expect(locator.fileURL == locationURL)
     #expect(locator.directoryURL == directoryURL)
   }
 }


### PR DESCRIPTION
Improved the implementation of the `ConfigurationLocator`, and removed default value of the `<configuration>` option in the `generate` command.