### PR TITLE
Improve Access Level in Source Code Stencils

### DIFF
--- a/Sources/DesignTokensGenerator/Resources/color+swiftui.stencil
+++ b/Sources/DesignTokensGenerator/Resources/color+swiftui.stencil
@@ -12,7 +12,7 @@ import SwiftUI
   /// {{ token.description }}
   {% endif %}
   {% set tokenName %}{{ token.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords }}{% endset %}
-  static let {{ tokenName }} = {%+  call colorValue token.color +%}
+  public static let {{ tokenName }} = {%+  call colorValue token.color +%}
   {% endfor %}
 {% endmacro %}
 

--- a/Sources/DesignTokensGenerator/Resources/color+uikit.stencil
+++ b/Sources/DesignTokensGenerator/Resources/color+uikit.stencil
@@ -12,7 +12,7 @@ import UIKit
   /// {{ token.description }}
   {% endif %}
   {% set tokenName %}{{ token.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords }}{% endset %}
-  static let {{ tokenName }} = {%+  call colorValue token.color +%}
+  public static let {{ tokenName }} = {%+  call colorValue token.color +%}
   {% endfor %}
 {% endmacro %}
 

--- a/Sources/DesignTokensGenerator/Resources/common.stencil
+++ b/Sources/DesignTokensGenerator/Resources/common.stencil
@@ -2,6 +2,6 @@
   {% for alias in aliases %}
   {% set aliasName %}{{alias.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
   {% set referenceName %}{{alias.reference|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  static var {{aliasName}}: {{aliasType}} { {{referenceName}} }
+  public static var {{aliasName}}: {{aliasType}} { {{referenceName}} }
   {% endfor %}
 {% endmacro %}

--- a/Sources/DesignTokensGenerator/Resources/dimension+foundation.stencil
+++ b/Sources/DesignTokensGenerator/Resources/dimension+foundation.stencil
@@ -11,7 +11,7 @@ import Foundation
   /// {{ token.description }}
   {% endif %}
   {% set tokenName %}{{ token.path|join:", "|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords }}{% endset %}
-  static let {{ tokenName }}: {{tokenType}} = {{ token.dimension.value }}
+  public static let {{ tokenName }}: {{tokenType}} = {{ token.dimension.value }}
   {% endfor %}
 {% endmacro %}
 


### PR DESCRIPTION
Improved the access level of tokens, which now defaults to `public`, in the generated source code.

This change allows users to include the generated source code as part of a framework so that they can share the code across modules.

Access level customization will be addressed with #14.